### PR TITLE
make demo works on 2021-8

### DIFF
--- a/demo/edit-meta
+++ b/demo/edit-meta
@@ -12,4 +12,4 @@ if __name__ == '__main__':
   if args.metadata:
     value = yaml.load(args.metadata, Loader=yaml.Loader)
     data['metadata'] = value
-  print yaml.dump(data, indent=2, default_flow_style=False, Dumper=yaml.Dumper)
+  print(yaml.dump(data, indent=2, default_flow_style=False, Dumper=yaml.Dumper))

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -31,7 +31,7 @@ k2="kubectl --kubeconfig ${kubeconfig2}"
 
 if [ ! -z "${BUILD_CONTROLLER}" ] || [ -z "$(docker images mcs-api-controller -q)" ]; then
   pushd ../
-  make -f kubebuilder.mk docker-build
+  make docker-build
   popd
 fi
 
@@ -50,7 +50,7 @@ function pod_cidrs() {
 
 function add_routes() {
   unset IFS
-  routes=$(kubectl --kubeconfig ${2} get nodes -o jsonpath='{range .items[*]}ip route add {.spec.podCIDR} via {.status.addresses[?(.type=="InternalIP")].address}{"\n"}')
+  routes=$(kubectl --kubeconfig ${2} get nodes -o jsonpath='{range .items[*]}ip route add {.spec.podCIDR} via {.status.addresses[?(.type=="InternalIP")].address}{"\n"}{end}')
   echo "Connecting cluster ${1} to ${2}"
 
   IFS=$'\n'


### PR DESCRIPTION
That's a very valuable project in multiple-cluster scenario.
So I hope the demo could works to show the functionalities to new comers.

Make it work on 2021-8 
```
root@rentz1:~/go/src/github.com/kubernetes-sigs/mcs-api# python --version
Python 3.8.0
```
k8s version:
```
root@rentz1:~/go/src/github.com/kubernetes-sigs/mcs-api# kubectl version
Client Version: version.Info{Major:"1", Minor:"22", GitVersion:"v1.22.1", GitCommit:"632ed300f2c34f6d6d15ca4cef3d3c7073412212", GitTreeState:"clean", BuildDate:"2021-08-19T15:45:37Z", GoVersion:"go1.16.7", Compiler:"gc", Platform:"linux/amd64"}
Server Version: version.Info{Major:"1", Minor:"20", GitVersion:"v1.20.2", GitCommit:"faecb196815e248d3ecfb03c680a4507229c2a56", GitTreeState:"clean", BuildDate:"2021-01-21T01:11:42Z", GoVersion:"go1.15.5", Compiler:"gc", Platform:"linux/amd64"}
```