### PR TITLE
Remove ServiceExportConditionType

### DIFF
--- a/pkg/apis/v1alpha1/serviceexport.go
+++ b/pkg/apis/v1alpha1/serviceexport.go
@@ -47,22 +47,19 @@ type ServiceExportStatus struct {
 	Conditions []metav1.Condition `json:"conditions,omitempty" patchStrategy:"merge" patchMergeKey:"type"`
 }
 
-// ServiceExportConditionType identifies a specific condition.
-type ServiceExportConditionType string
-
 const (
 	// ServiceExportValid means that the service referenced by this
 	// service export has been recognized as valid by an mcs-controller.
 	// This will be false if the service is found to be unexportable
 	// (ExternalName, not found).
-	ServiceExportValid ServiceExportConditionType = "Valid"
+	ServiceExportValid = "Valid"
 	// ServiceExportConflict means that there is a conflict between two
 	// exports for the same Service. When "True", the condition message
 	// should contain enough information to diagnose the conflict:
 	// field(s) under contention, which cluster won, and why.
 	// Users should not expect detailed per-cluster information in the
 	// conflict message.
-	ServiceExportConflict ServiceExportConditionType = "Conflict"
+	ServiceExportConflict = "Conflict"
 )
 
 // +kubebuilder:object:root=true


### PR DESCRIPTION
Now that `ServiceExportCondition` has been replaced by `metav1.Condition`, the `ServiceExportConditionType` is no longer used nor necessary. Change the constants to type string to match `Condition.Type`, which also avoids unnecessary casting.
