### PR TITLE
Avoid crashing while waiting for the hello pod IP

### DIFF
--- a/e2etest/connectivity_test.go
+++ b/e2etest/connectivity_test.go
@@ -196,7 +196,10 @@ var _ = Describe("Connectivity", func() {
 				LabelSelector: metav1.FormatLabelSelector(helloDeployment.Spec.Selector),
 			})
 			Expect(err).ToNot(HaveOccurred())
-			return pods.Items[0].Status.PodIP
+			if len(pods.Items) > 0 {
+				return pods.Items[0].Status.PodIP
+			}
+			return ""
 		}, 30).ShouldNot(BeEmpty())
 		pods, err = cluster2.k8s.CoreV1().Pods(namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: metav1.FormatLabelSelector(helloDeployment.Spec.Selector),


### PR DESCRIPTION
After listing the hello pods, check whether the list is empty before dereferencing the first one. Conceivably the "eventually" expectation could be changed to check the list itself, but we're really interested in waiting for the pod to have an IP address, so this preserves that behaviour.

Signed-off-by: Stephen Kitt <skitt@redhat.com>