### PR TITLE
Add constant for well-known source cluster label

### DIFF
--- a/pkg/apis/v1alpha1/well_known_labels.go
+++ b/pkg/apis/v1alpha1/well_known_labels.go
@@ -20,4 +20,7 @@ const (
 	// LabelServiceName is used to indicate the name of multi-cluster service
 	// that an EndpointSlice belongs to.
 	LabelServiceName = "multicluster.kubernetes.io/service-name"
+
+	// LabelSourceCluster is used to indicate the name of the cluster in which an exported resource exists.
+	LabelSourceCluster = "multicluster.kubernetes.io/source-cluster"
 )


### PR DESCRIPTION
The [MCS spec](https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#importing-services) defines the well-known `multicluster.kubernetes.io/source-cluster` label so add a constant.
