### PR TITLE
update appProtocol definition based to align with k8s 1.27

### DIFF
--- a/pkg/apis/v1alpha1/serviceimport.go
+++ b/pkg/apis/v1alpha1/serviceimport.go
@@ -89,10 +89,17 @@ type ServicePort struct {
 	Protocol v1.Protocol `json:"protocol,omitempty"`
 
 	// The application protocol for this port.
+	// This is used as a hint for implementations to offer richer behavior for protocols that they understand.
 	// This field follows standard Kubernetes label syntax.
-	// Un-prefixed names are reserved for IANA standard service names (as per
-	// RFC-6335 and http://www.iana.org/assignments/service-names).
-	// Non-standard protocols should use prefixed names such as
+	// Valid values are either:
+	//
+	// * Un-prefixed protocol names - reserved for IANA standard service names (as per
+	// RFC-6335 and https://www.iana.org/assignments/service-names).
+	//
+	// * Kubernetes-defined prefixed names:
+	//   * 'kubernetes.io/h2c' - HTTP/2 over cleartext as described in https://www.rfc-editor.org/rfc/rfc7540
+	//
+	// * Other protocols should use implementation-defined prefixed names such as
 	// mycompany.com/my-custom-protocol.
 	// Field can be enabled with ServiceAppProtocol feature gate.
 	// +optional


### PR DESCRIPTION
AppProtocol description has changed and new standards were introduced in 1.27 (see  https://github.com/kubernetes/kubernetes/pull/116866 & https://github.com/kubernetes/kubernetes/pull/115433 )

Let me know if I should change in other places or run a make command to auto-generate other files

/cc @arkodg