### PR TITLE
Update golang builder image to 1.19 to stay in support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.18 as builder
+FROM golang:1.19 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests


### PR DESCRIPTION
This pull request is a quick follow-on from https://github.com/kubernetes-sigs/mcs-api/pull/38 to ensure the Dockerfile also uses a supported golang version.

/kind cleanup