### PR TITLE
Bump to go 1.20 as 1.19 is now out of support 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ Session.vim
 .vscode
 /www/test_out
 .*.timestamp
+sigs.k8s.io/

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.19 as builder
+FROM golang:1.20 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/conformance/conformance_suite_test.go
+++ b/conformance/conformance_suite_test.go
@@ -18,7 +18,6 @@ package conformance
 
 import (
 	"flag"
-	"math/rand"
 	"strings"
 	"testing"
 
@@ -53,8 +52,6 @@ func init() {
 }
 
 var _ = BeforeSuite(func() {
-	rand.Seed(GinkgoRandomSeed())
-
 	Expect(setupClients()).To(Succeed())
 })
 

--- a/e2etest/e2e_suite_test.go
+++ b/e2etest/e2e_suite_test.go
@@ -19,7 +19,6 @@ package e2etest
 import (
 	"bytes"
 	"flag"
-	"math/rand"
 	"os"
 	"strconv"
 	"testing"
@@ -63,8 +62,6 @@ func TestE2E(t *testing.T) {
 }
 
 var _ = BeforeSuite(func() {
-	rand.Seed(GinkgoRandomSeed())
-
 	Expect(*kubeconfig1).ToNot(BeEmpty(), "either --kubeconfig1 or KUBECONFIG1 must be set")
 	Expect(*kubeconfig2).ToNot(BeEmpty(), "either --kubeconfig2 or KUBECONFIG2 must be set")
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module sigs.k8s.io/mcs-api
 
-go 1.19
+go 1.20
 
 require (
 	github.com/go-logr/logr v1.2.3

--- a/pkg/controllers/controllers_suite_test.go
+++ b/pkg/controllers/controllers_suite_test.go
@@ -19,7 +19,6 @@ package controllers
 import (
 	"context"
 	"fmt"
-	"math/rand"
 	"path/filepath"
 	"testing"
 	"time"
@@ -54,7 +53,6 @@ var (
 )
 
 var _ = BeforeSuite(func(done Done) {
-	rand.Seed(GinkgoRandomSeed())
 	log.SetLogger(zap.New(zap.UseDevMode(true), zap.WriteTo(GinkgoWriter)))
 	// Use Kind for a more up-to-date K8s
 	clusterProvider = cluster.NewProvider()


### PR DESCRIPTION
Golang 1.21 has now been released recently:

* https://groups.google.com/g/golang-announce/c/Mk0Jar6hfhI
* https://go.dev/doc/go1.21

This means 1.19 is now out of support so we should consider adopting 1.20. This would also bring mcs-api in line with kubernetes/kubernetes go version.

As part of the update to Go 1.20 minor release, math/rand.Seed is marked "Deprecated":

>Prior to Go 1.20, the generator was seeded like Seed(1) at program startup.
  To force the old behavior, call Seed(1) at program startup.
 Alternately, set GODEBUG=randautoseed=0 in the environment
 before making any calls to functions in this package.

 > Deprecated: As of Go 1.20 there is no reason to call Seed with
 a random value. Programs that call Seed with a known value to get
 a specific sequence of results should use New(NewSource(seed)) to
obtain a local random generator.

this pull request proposes removing the .Seed calls as global random is now seeded automatically 