### PR TITLE
configure coredns with multicluster for e2e

### DIFF
--- a/e2etest/connectivity_test.go
+++ b/e2etest/connectivity_test.go
@@ -317,4 +317,34 @@ var _ = Describe("Connectivity", func() {
 			return successfulChecks
 		}).Should(BeNumerically(">=", 50))
 	})
+	Specify("UDP connects across clusters using the DNS name", func() {
+		successfulChecks := 0
+		command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc -uw1 %s.%s.svc.clusterset.local 42", serviceImport.Name, serviceImport.Namespace)}
+		for i := 0; i <= 59; i++ {
+			stout, _, err := execCmd(cluster1.k8s, restcfg1, reqPod.Name, reqPod.Namespace, command)
+			Expect(err).ToNot(HaveOccurred())
+			ip := strings.TrimSpace(string(stout))
+			if ip == strings.TrimSpace(pods.Items[0].Status.PodIP) {
+				successfulChecks++
+			}
+		}
+		Eventually(func() int {
+			return successfulChecks
+		}).Should(BeNumerically(">=", 50))
+	})
+	Specify("TCP connects across clusters using the DNS name", func() {
+		successfulChecks := 0
+		command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42", serviceImport.Name, serviceImport.Namespace)}
+		for i := 0; i <= 59; i++ {
+			stout, _, err := execCmd(cluster1.k8s, restcfg1, reqPod.Name, reqPod.Namespace, command)
+			Expect(err).ToNot(HaveOccurred())
+			ip := strings.TrimSpace(string(stout))
+			if ip == strings.TrimSpace(pods.Items[0].Status.PodIP) {
+				successfulChecks++
+			}
+		}
+		Eventually(func() int {
+			return successfulChecks
+		}).Should(BeNumerically(">=", 50))
+	})
 })

--- a/scripts/c1.yaml
+++ b/scripts/c1.yaml
@@ -5,3 +5,9 @@ networking:
   serviceSubnet: "10.11.0.0/16"
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+    - |
+      kind: ClusterConfiguration
+      dns:
+        imageRepository: multicluster
+        imageTag: latest

--- a/scripts/c2.yaml
+++ b/scripts/c2.yaml
@@ -5,3 +5,9 @@ networking:
   serviceSubnet: "10.13.0.0/16"
 nodes:
 - role: control-plane
+  kubeadmConfigPatches:
+    - |
+      kind: ClusterConfiguration
+      dns:
+        imageRepository: multicluster
+        imageTag: latest

--- a/scripts/coredns-rbac.json
+++ b/scripts/coredns-rbac.json
@@ -1,0 +1,18 @@
+[
+  {
+    "op": "add",
+    "path": "/rules/-",
+    "value": {
+      "apiGroups": [
+        "multicluster.x-k8s.io"
+      ],
+      "resources": [
+        "serviceimports"
+      ],
+      "verbs": [
+        "list",
+        "watch"
+      ]
+    }
+  }
+]


### PR DESCRIPTION
This PR extends the existing connectivity test to also verify that the service is reachable via its `*.clusterset.local` domain in addition to its IP. Most of these changes involve setting up CoreDNS with the multicluster plugin: https://github.com/coredns/multicluster