### PR TITLE
Add conformance_suite_test.go generated by ginkgo bootstrap

### DIFF
--- a/conformance/conformance_suite_test.go
+++ b/conformance/conformance_suite_test.go
@@ -1,0 +1,13 @@
+package conformance_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestConformance(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Conformance Suite")
+}


### PR DESCRIPTION
...to allow the test suite to be executed via the `ginkgo` CLI in addition to the public entry point in _conformance_suite.go_.