### PR TITLE
Adjustments to conformance report

### DIFF
--- a/conformance/connectivity_test.go
+++ b/conformance/connectivity_test.go
@@ -77,7 +77,7 @@ var _ = Describe("Connectivity to remote services", func() {
 						for i := 0; i < 20; i++ {
 							command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42", helloService.Name, namespace)}
 							stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, namespace, command)
-							Expect(string(stdout)).NotTo(ContainSubstring("pod ip"))
+							Expect(string(stdout)).NotTo(ContainSubstring("pod ip"), reportNonConformant(""))
 						}
 					}
 				})
@@ -101,7 +101,7 @@ var _ = Describe("Connectivity to remote services", func() {
 					Eventually(func() string {
 						stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, namespace, command)
 						return string(stdout)
-					}, 20, 1).Should(ContainSubstring("pod ip"))
+					}, 20, 1).Should(ContainSubstring("pod ip"), reportNonConformant(""))
 				}
 			})
 		})

--- a/conformance/report.go
+++ b/conformance/report.go
@@ -18,32 +18,68 @@ package conformance
 
 import (
 	_ "embed"
+	"errors"
+	"fmt"
 	"html/template"
 	"os"
+	"regexp"
+	"slices"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
+	"github.com/onsi/gomega/matchers"
 )
 
 const (
-	OptionalLabel      = "Optional"
-	RequiredLabel      = "Required"
-	SpecRefReportEntry = "spec-ref"
+	OptionalLabel            = "Optional"
+	RequiredLabel            = "Required"
+	SpecRefReportEntry       = "spec-ref"
+	NonConformantReportEntry = "non-conformant"
 )
+
+var reportingLabels = []string{
+	RequiredLabel,
+	OptionalLabel,
+}
 
 //go:embed report_template.gohtml
 var reportHTML string
 
 type testInfo struct {
-	Desc string
-	Ref  string
-	Pass bool
+	Desc       string
+	Ref        string
+	Failed     bool
+	Conformant bool
+	Message    string
 }
 
 type testGrouping struct {
 	Name  string
 	Tests []testInfo
+}
+
+var errorRegEx *regexp.Regexp
+
+func init() {
+	dummyErr := errors.New("dummy")
+
+	// Matches gomega output for an error rendered by either the HaveOccurred or Success matchers, eg
+	//
+	// "Error retrieving resource
+	// Unexpected error:
+	//      <*errors.StatusError | 0x400024e820>:
+	//       "foo" not found
+	//      {
+	//          ...
+	//      }
+	//  occurred"
+	//
+	// In this case, we want to match and extract: "Error retrieving resource" and ""foo" not found".
+	errorRegEx = regexp.MustCompile(fmt.Sprintf(`\s*(.*)\s*(?:%s|%s)[^:]*:([^{]*)`,
+		firstLine((&matchers.HaveOccurredMatcher{}).NegatedFailureMessage(dummyErr)),
+		firstLine((&matchers.SucceedMatcher{}).FailureMessage(dummyErr))))
 }
 
 var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
@@ -55,33 +91,52 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 			continue
 		}
 
-		for _, label := range specReport.Labels() {
+		for _, label := range reportingLabels {
+			if !slices.Contains(specReport.Labels(), label) {
+				continue
+			}
+
 			if testGroupMap[label] == nil {
 				testGroupMap[label] = &testGrouping{
 					Name: label,
 				}
 			}
 
-			ref := ""
+			info := testInfo{
+				Desc:       specReport.FullText(),
+				Conformant: true,
+			}
+
 			for i := range specReport.ReportEntries {
 				if specReport.ReportEntries[i].Name == SpecRefReportEntry {
-					ref = specReport.ReportEntries[i].GetRawValue().(string)
-					break
+					info.Ref = specReport.ReportEntries[i].GetRawValue().(string)
+				} else if specReport.ReportEntries[i].Name == NonConformantReportEntry {
+					info.Conformant = false
+					info.Message = specReport.ReportEntries[i].GetRawValue().(string)
 				}
 			}
 
-			testGroupMap[label].Tests = append(testGroupMap[label].Tests, testInfo{
-				Desc: specReport.FullText(),
-				Ref:  ref,
-				Pass: specReport.State == types.SpecStatePassed,
-			})
+			// If the spec failed (ie didn't pass) not due to non-conformance then we assume it encountered
+			// an unexpected error preventing conformance from being determined, and thus we'll report the
+			// conformance status as unknown.
+			if specReport.State != types.SpecStatePassed && info.Conformant {
+				info.Failed = true
+				info.Message = parseFailureMessage(specReport.FailureMessage())
+			}
+
+			if info.Message != "" {
+				info.Message = " - " + info.Message
+			}
+
+			testGroupMap[label].Tests = append(testGroupMap[label].Tests, info)
 		}
 	}
 
-	var testGroups []testGrouping
-
-	for _, g := range testGroupMap {
-		testGroups = append(testGroups, *g)
+	testGroups := make([]testGrouping, len(testGroupMap))
+	for i, l := range reportingLabels {
+		if testGroupMap[l] != nil {
+			testGroups[i] = *testGroupMap[l]
+		}
 	}
 
 	data := struct {
@@ -99,3 +154,40 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 	err = tmpl.Execute(out, data)
 	Expect(err).To(Succeed())
 })
+
+func parseFailureMessage(s string) string {
+	// First see if the message represents an error formatted by a gomega matcher - we're interested in
+	// extracting the optional user description passed to the gomega assertion and the actual error
+	// string as these are the useful parts conducive for formatting in the report table.
+	matches := errorRegEx.FindStringSubmatch(s)
+	if len(matches) > 0 {
+		// First match at index 0 is the full text that was matched; index 1 will be the user description
+		// and index 2 the error string. We concatenate the latter two.
+		msg := strings.TrimSpace(matches[1])
+		if msg == "" {
+			msg = strings.TrimSpace(matches[2])
+		} else {
+			msg = msg + ": " + strings.TrimSpace(matches[2])
+		}
+
+		return msg
+	}
+
+	// Fallback - just take the first line in the message.
+	return firstLine(s)
+}
+
+func firstLine(s string) string {
+	first, _, _ := strings.Cut(s, "\n")
+	return strings.TrimSpace(first)
+}
+
+// reportNonConformant is intended for use as an optional description in a gomega assertion. It returns
+// a function that is lazily evaluated by the assertion only if a failure occurs. We take advantage of
+// that to add a report entry indicating non-conformance.
+func reportNonConformant(msg string) func() string {
+	return func() string {
+		AddReportEntry(NonConformantReportEntry, msg)
+		return msg
+	}
+}

--- a/conformance/report_template.gohtml
+++ b/conformance/report_template.gohtml
@@ -20,16 +20,18 @@
 <table>
     <thead>
         <tr>
-            <th>Result</th>
+            <th>Conformant</th>
             <th>Description</th>
         </tr>
     </thead>
     {{range .Tests}}
     <tr>
-        {{ if .Pass }}
-        <td style="color:green">Pass</td>
+        {{ if .Failed }}
+            <td style="color:gray">Unknown{{.Message}}</td>
+        {{ else if .Conformant }}
+            <td style="color:green">Yes{{.Message}}</td>
         {{ else }}
-        <td style="color:red">Fail</td>
+            <td style="color:red">No{{.Message}}</td>
         {{end}}
         <td><a href="{{.Ref}}">{{.Desc}}</a></td>
     </tr>


### PR DESCRIPTION
Changed the "Result" column to "Conformant" with values "Yes", "No", and "Unknown". The latter reflects the case where an unexpected error occurs preventing conformance from being determined. The column value can be augmented with additional text describing the reason, eg for "Unknown" the error details would be included.

The test specs report non-conformance via a description function that is passed to Gomaga assertions that is lazily evaluated by the assertion only if a failure occurs. The function adds a report entry named "non-conformant" with an optional message string that is used by the reporting backend to distinguish between a spec failure due to non-conformance or one due to an unexpected error/failure.

<img width="1001" alt="Screenshot 2024-08-19 at 10 41 13 AM" src="https://github.com/user-attachments/assets/fb2edefe-372b-4694-a9f3-5cae53312682">
