### PR TITLE
Add conformance tests to validate generated ServiceImport

### DIFF
--- a/conformance/connectivity_test.go
+++ b/conformance/connectivity_test.go
@@ -17,54 +17,14 @@ limitations under the License.
 package conformance
 
 import (
-	"context"
 	"fmt"
-	"math/rand"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
-	v1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 var _ = Describe("Connectivity to remote services", func() {
-	ctx := context.TODO()
-
-	// Shared namespace
-	var namespace string
-
-	BeforeEach(func() {
-		Expect(clients).ToNot(BeEmpty())
-
-		// Set up the shared namespace
-		namespace = fmt.Sprintf("mcs-conformance-%v", rand.Uint32())
-		for _, client := range clients {
-			_, err := client.k8s.CoreV1().Namespaces().Create(ctx, &v1.Namespace{
-				ObjectMeta: metav1.ObjectMeta{Name: namespace},
-			}, metav1.CreateOptions{})
-			Expect(err).ToNot(HaveOccurred())
-		}
-
-		// Set up the remote service (the first cluster is considered to be the remote)
-		_, err := clients[0].k8s.AppsV1().Deployments(namespace).Create(ctx, &helloDeployment, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-		_, err = clients[0].k8s.CoreV1().Services(namespace).Create(ctx, &helloService, metav1.CreateOptions{})
-		Expect(err).ToNot(HaveOccurred())
-
-		// Start the request pod on all clusters
-		for _, client := range clients {
-			startRequestPod(ctx, client, namespace)
-		}
-	})
-
-	AfterEach(func() {
-		// Clean up the shared namespace
-		for _, client := range clients {
-			err := client.k8s.CoreV1().Namespaces().Delete(ctx, namespace, metav1.DeleteOptions{})
-			Expect(err).ToNot(HaveOccurred())
-		}
-	})
+	t := newTestDriver()
 
 	Context("with no exported service", func() {
 		It("should be inaccessible", Label(RequiredLabel), func() {
@@ -75,8 +35,9 @@ var _ = Describe("Connectivity to remote services", func() {
 					for _, client := range clients {
 						// Repeat multiple times
 						for i := 0; i < 20; i++ {
-							command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42", helloService.Name, namespace)}
-							stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, namespace, command)
+							command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42",
+								helloService.Name, t.namespace)}
+							stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, t.namespace, command)
 							Expect(string(stdout)).NotTo(ContainSubstring("pod ip"), reportNonConformant(""))
 						}
 					}
@@ -85,21 +46,20 @@ var _ = Describe("Connectivity to remote services", func() {
 		})
 	})
 
-	Context("with an exported service", func() {
+	Context("with an exported ClusterIP service", func() {
 		It("should be accessible through DNS (after a potential delay)", Label(OptionalLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 			By("exporting the service", func() {
 				// On the "remote" cluster
-				_, err := clients[0].mcs.MulticlusterV1alpha1().ServiceExports(namespace).Create(ctx,
-					&v1alpha1.ServiceExport{ObjectMeta: metav1.ObjectMeta{Name: helloService.Name}}, metav1.CreateOptions{})
-				Expect(err).ToNot(HaveOccurred())
+				t.createServiceExport()
 			})
 			By("issuing a request from all clusters", func() {
 				// Run on all clusters
 				for _, client := range clients {
-					command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42", helloService.Name, namespace)}
+					command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42",
+						helloService.Name, t.namespace)}
 					Eventually(func() string {
-						stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, namespace, command)
+						stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, t.namespace, command)
 						return string(stdout)
 					}, 20, 1).Should(ContainSubstring("pod ip"), reportNonConformant(""))
 				}

--- a/conformance/k8s_objects.go
+++ b/conformance/k8s_objects.go
@@ -43,6 +43,10 @@ var helloService = v1.Service{
 				Protocol: v1.ProtocolUDP,
 			},
 		},
+		SessionAffinity: v1.ServiceAffinityClientIP,
+		SessionAffinityConfig: &v1.SessionAffinityConfig{
+			ClientIP: &v1.ClientIPConfig{TimeoutSeconds: ptr.To(int32(10))},
+		},
 	},
 }
 

--- a/conformance/report.go
+++ b/conformance/report.go
@@ -132,10 +132,10 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 		}
 	}
 
-	testGroups := make([]testGrouping, len(testGroupMap))
-	for i, l := range reportingLabels {
+	testGroups := []testGrouping{}
+	for _, l := range reportingLabels {
 		if testGroupMap[l] != nil {
-			testGroups[i] = *testGroupMap[l]
+			testGroups = append(testGroups, *testGroupMap[l])
 		}
 	}
 

--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -1,0 +1,70 @@
+package conformance
+
+import (
+	"fmt"
+	"net"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
+)
+
+var _ = Describe("", func() {
+	t := newTestDriver()
+
+	BeforeEach(func() {
+		t.createServiceExport()
+	})
+
+	Specify("Exporting a ClusterIP service should create a ServiceImport of type ClusterSetIP in the service's namespace in each cluster",
+		Label(RequiredLabel), func() {
+			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#importing-services")
+
+			for i := range clients {
+				serviceImport := t.awaitServiceImport(&clients[i], helloService.Name, nil)
+				Expect(serviceImport).NotTo(BeNil(), reportNonConformant(fmt.Sprintf("ServiceImport was not found on cluster %d", i+1)))
+
+				Expect(serviceImport.Spec.Type).To(Equal(v1alpha1.ClusterSetIP), reportNonConformant(
+					fmt.Sprintf("ServiceImport on cluster %d has type %q", i+1, serviceImport.Spec.Type)))
+			}
+		})
+
+	Specify("The ports for a ClusterSetIP ServiceImport should match those of the exported service",
+		Label(RequiredLabel), func() {
+			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port")
+
+			serviceImport := t.awaitServiceImport(&clients[0], helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
+				return len(serviceImport.Spec.Ports) > 0
+			})
+			Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
+
+			Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(helloService.Spec.Ports)), reportNonConformant(""))
+		})
+
+	Specify("The SessionAffinity for a ClusterSetIP ServiceImport should match the exported service's SessionAffinity",
+		Label(RequiredLabel), func() {
+			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#session-affinity")
+
+			serviceImport := t.awaitServiceImport(&clients[0], helloService.Name, nil)
+			Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
+
+			Expect(serviceImport.Spec.SessionAffinity).To(Equal(helloService.Spec.SessionAffinity), reportNonConformant(""))
+
+			Expect(serviceImport.Spec.SessionAffinityConfig).To(Equal(helloService.Spec.SessionAffinityConfig), reportNonConformant(
+				"The SessionAffinityConfig of the ServiceImport does not match the exported Service's SessionAffinityConfig"))
+		})
+
+	Specify("An IP should be allocated for a ClusterSetIP ServiceImport",
+		Label(RequiredLabel), func() {
+			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#clustersetip")
+
+			serviceImport := t.awaitServiceImport(&clients[0], helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
+				return len(serviceImport.Spec.IPs) > 0
+			})
+			Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
+
+			Expect(serviceImport.Spec.IPs).ToNot(BeEmpty(), reportNonConformant(""))
+			Expect(net.ParseIP(serviceImport.Spec.IPs[0])).ToNot(BeNil(),
+				reportNonConformant(fmt.Sprintf("The value %q is not a valid IP", serviceImport.Spec.IPs[0])))
+		})
+})


### PR DESCRIPTION
Added checks:

- a ServiceImport is created in each cluster
- the service ports are propagated to the ServiceImport
- the session affinity config is propagated to the ServiceImport
- a clusterset IP is allocated for the ServiceImport

Signed-off-by: Tom Pantelis <tompantelis@gmail.com>