### PR TITLE
Add DNS label to conformance connectivity test

### DIFF
--- a/conformance/connectivity_test.go
+++ b/conformance/connectivity_test.go
@@ -47,7 +47,7 @@ var _ = Describe("Connectivity to remote services", func() {
 	})
 
 	Context("with an exported ClusterIP service", func() {
-		It("should be accessible through DNS (after a potential delay)", Label(OptionalLabel), func() {
+		It("should be accessible through DNS (after a potential delay)", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 			By("exporting the service", func() {
 				// On the "remote" cluster

--- a/conformance/report.go
+++ b/conformance/report.go
@@ -35,6 +35,8 @@ import (
 const (
 	OptionalLabel            = "Optional"
 	RequiredLabel            = "Required"
+	DNSLabel                 = "DNS"
+	ClusterIPLabel           = "ClusterIP"
 	SpecRefReportEntry       = "spec-ref"
 	NonConformantReportEntry = "non-conformant"
 )


### PR DESCRIPTION
This test is optional so the specific label will allow users to skip the test rather then have it always fail if not implemented.