### PR TITLE
Add conformance tests for service ports

### DIFF
--- a/conformance/connectivity.go
+++ b/conformance/connectivity.go
@@ -36,8 +36,8 @@ var _ = Describe("Connectivity to remote services", func() {
 						// Repeat multiple times
 						for i := 0; i < 20; i++ {
 							command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42",
-								helloService.Name, t.namespace)}
-							stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, t.namespace, command)
+								t.helloService.Name, t.namespace)}
+							stdout, _, _ := execCmd(client.k8s, client.rest, t.requestPod.Name, t.namespace, command)
 							Expect(string(stdout)).NotTo(ContainSubstring("pod ip"), reportNonConformant(""))
 						}
 					}
@@ -51,15 +51,15 @@ var _ = Describe("Connectivity to remote services", func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 			By("exporting the service", func() {
 				// On the "remote" cluster
-				t.createServiceExport()
+				t.createServiceExport(&clients[0])
 			})
 			By("issuing a request from all clusters", func() {
 				// Run on all clusters
 				for _, client := range clients {
 					command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42",
-						helloService.Name, t.namespace)}
+						t.helloService.Name, t.namespace)}
 					Eventually(func() string {
-						stdout, _, _ := execCmd(client.k8s, client.rest, requestPod.Name, t.namespace, command)
+						stdout, _, _ := execCmd(client.k8s, client.rest, t.requestPod.Name, t.namespace, command)
 						return string(stdout)
 					}, 20, 1).Should(ContainSubstring("pod ip"), reportNonConformant(""))
 				}

--- a/conformance/framework.go
+++ b/conformance/framework.go
@@ -26,7 +26,6 @@ import (
 	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
@@ -133,20 +132,4 @@ func execCmd(k8s kubernetes.Interface, config *rest.Config, podName string, podN
 	}
 
 	return stdout.Bytes(), stderr.Bytes(), nil
-}
-
-func startRequestPod(ctx context.Context, client clusterClients, namespace string) {
-	_, err := client.k8s.CoreV1().Pods(namespace).Create(ctx, &requestPod, metav1.CreateOptions{})
-	Expect(err).ToNot(HaveOccurred())
-
-	Eventually(func() error {
-		pod, err := client.k8s.CoreV1().Pods(namespace).Get(ctx, requestPod.Name, metav1.GetOptions{})
-		if err != nil {
-			return err
-		}
-		if pod.Status.Phase != v1.PodRunning {
-			return fmt.Errorf("pod is not running yet, current status %v", pod.Status.Phase)
-		}
-		return nil
-	}, 20, 1).Should(Succeed())
 }

--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -19,17 +19,19 @@ package conformance
 import (
 	"fmt"
 	"net"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
 var _ = Describe("", func() {
 	t := newTestDriver()
 
-	BeforeEach(func() {
-		t.createServiceExport()
+	JustBeforeEach(func() {
+		t.createServiceExport(&clients[0])
 	})
 
 	Specify("Exporting a ClusterIP service should create a ServiceImport of type ClusterSetIP in the service's namespace in each cluster",
@@ -37,7 +39,7 @@ var _ = Describe("", func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#importing-services")
 
 			for i := range clients {
-				serviceImport := t.awaitServiceImport(&clients[i], helloService.Name, nil)
+				serviceImport := t.awaitServiceImport(&clients[i], helloServiceName, nil)
 				Expect(serviceImport).NotTo(BeNil(), reportNonConformant(fmt.Sprintf("ServiceImport was not found on cluster %d", i+1)))
 
 				Expect(serviceImport.Spec.Type).To(Equal(v1alpha1.ClusterSetIP), reportNonConformant(
@@ -49,24 +51,24 @@ var _ = Describe("", func() {
 		Label(RequiredLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port")
 
-			serviceImport := t.awaitServiceImport(&clients[0], helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
+			serviceImport := t.awaitServiceImport(&clients[0], helloServiceName, func(serviceImport *v1alpha1.ServiceImport) bool {
 				return len(serviceImport.Spec.Ports) > 0
 			})
 			Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
 
-			Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(helloService.Spec.Ports)), reportNonConformant(""))
+			Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(t.helloService.Spec.Ports)), reportNonConformant(""))
 		})
 
 	Specify("The SessionAffinity for a ClusterSetIP ServiceImport should match the exported service's SessionAffinity",
 		Label(RequiredLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#session-affinity")
 
-			serviceImport := t.awaitServiceImport(&clients[0], helloService.Name, nil)
+			serviceImport := t.awaitServiceImport(&clients[0], helloServiceName, nil)
 			Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
 
-			Expect(serviceImport.Spec.SessionAffinity).To(Equal(helloService.Spec.SessionAffinity), reportNonConformant(""))
+			Expect(serviceImport.Spec.SessionAffinity).To(Equal(t.helloService.Spec.SessionAffinity), reportNonConformant(""))
 
-			Expect(serviceImport.Spec.SessionAffinityConfig).To(Equal(helloService.Spec.SessionAffinityConfig), reportNonConformant(
+			Expect(serviceImport.Spec.SessionAffinityConfig).To(Equal(t.helloService.Spec.SessionAffinityConfig), reportNonConformant(
 				"The SessionAffinityConfig of the ServiceImport does not match the exported Service's SessionAffinityConfig"))
 		})
 
@@ -74,7 +76,7 @@ var _ = Describe("", func() {
 		Label(RequiredLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#clustersetip")
 
-			serviceImport := t.awaitServiceImport(&clients[0], helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
+			serviceImport := t.awaitServiceImport(&clients[0], t.helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
 				return len(serviceImport.Spec.IPs) > 0
 			})
 			Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
@@ -83,4 +85,71 @@ var _ = Describe("", func() {
 			Expect(net.ParseIP(serviceImport.Spec.IPs[0])).ToNot(BeNil(),
 				reportNonConformant(fmt.Sprintf("The value %q is not a valid IP", serviceImport.Spec.IPs[0])))
 		})
+
+	Context("A service exported on two clusters", func() {
+		var helloService2 *corev1.Service
+
+		BeforeEach(func() {
+			requireTwoClusters()
+
+			helloService2 = newHelloService()
+		})
+
+		JustBeforeEach(func() {
+			// Sleep a little before deploying on the second cluster to ensure the first cluster's ServiceExport timestamp
+			// is older so conflict checking is deterministic.
+			time.Sleep(100 * time.Millisecond)
+
+			t.deployHelloService(&clients[1], helloService2)
+			t.createServiceExport(&clients[1])
+		})
+
+		Context("", func() {
+			BeforeEach(func() {
+				helloService2.Spec.Ports = []corev1.ServicePort{
+					t.helloService.Spec.Ports[0],
+					{
+						Name:     "stcp",
+						Port:     142,
+						Protocol: corev1.ProtocolSCTP,
+					},
+				}
+			})
+
+			Specify("should expose the union of the constituent service ports", Label(RequiredLabel), func() {
+				AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port")
+
+				serviceImport := t.awaitServiceImport(&clients[0], t.helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
+					return len(serviceImport.Spec.Ports) == 3
+				})
+				Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
+
+				Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(
+					append(t.helloService.Spec.Ports, helloService2.Spec.Ports[1]))), reportNonConformant(""))
+			})
+		})
+
+		Context("with conflicting ports", func() {
+			BeforeEach(func() {
+				helloService2.Spec.Ports = []corev1.ServicePort{t.helloService.Spec.Ports[0]}
+				helloService2.Spec.Ports[0].Port = t.helloService.Spec.Ports[0].Port + 1
+			})
+
+			Specify("should apply the conflict resolution policy and report a Conflict condition on each ServiceExport",
+				Label(RequiredLabel), func() {
+					AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port")
+
+					t.awaitServiceExportCondition(&clients[0], v1alpha1.ServiceExportConflict)
+					t.awaitServiceExportCondition(&clients[1], v1alpha1.ServiceExportConflict)
+
+					serviceImport := t.awaitServiceImport(&clients[0], t.helloService.Name, func(serviceImport *v1alpha1.ServiceImport) bool {
+						return len(serviceImport.Spec.Ports) == len(t.helloService.Spec.Ports)
+					})
+					Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
+
+					Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(t.helloService.Spec.Ports)),
+						reportNonConformant("The service ports were not resolved correctly"))
+				})
+		})
+	})
 })


### PR DESCRIPTION
When a service is exported from two clusters, ensure the clusterset service exposes the union of service ports declared on its constituent services. Also if port properties don't match, ensure the conflict resolution policy is properly applied.

Creation of K8s resources was refactored to functions rather than defined in global vars to allow the resources to be customized when created on multiple clusters.

Fixes https://github.com/kubernetes-sigs/mcs-api/issues/71