### PR TITLE
Update service controller to add all the IPs from derived service

### DIFF
--- a/pkg/controllers/service.go
+++ b/pkg/controllers/service.go
@@ -68,7 +68,7 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, nil
 	}
 
-	svcImport.Spec.IPs = []string{service.Spec.ClusterIP}
+	svcImport.Spec.IPs = service.Spec.ClusterIPs
 	if err := r.Client.Update(ctx, &svcImport); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Update the Service controller to update the ServiceImport with all the IPs instead of only the first IP.

A bit related to #63 might not be the complete answers though