### PR TITLE
Fix Go linting

### DIFF
--- a/conformance/clusterip_service_dns.go
+++ b/conformance/clusterip_service_dns.go
@@ -71,7 +71,7 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 		for _, client := range clients {
 			srvRecs := t.expectSRVRecords(&client, domainName)
 
-			expSRVRecs := []SRVRecord{{
+			expSRVRecs := []srvRecord{{
 				port:       t.helloService.Spec.Ports[0].Port,
 				domainName: domainName,
 			}}
@@ -108,14 +108,14 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 	})
 })
 
-func (t *testDriver) expectSRVRecords(c *clusterClients, domainName string) []SRVRecord {
+func (t *testDriver) expectSRVRecords(c *clusterClients, domainName string) []srvRecord {
 	command := []string{"sh", "-c", "nslookup -type=SRV " + domainName}
 
 	By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), c.name))
 
-	var srvRecs []SRVRecord
+	var srvRecs []srvRecord
 
-	Eventually(func() []SRVRecord {
+	Eventually(func() []srvRecord {
 		srvRecs = parseSRVRecords(t.execCmdOnRequestPod(c, command))
 		return srvRecs
 	}, 20, 1).ShouldNot(BeEmpty(), reportNonConformant(""))
@@ -130,19 +130,19 @@ func (t *testDriver) expectSRVRecords(c *clusterClients, domainName string) []SR
 // to extract the port and target domain name (the last two tokens)
 var srvRecordRegEx = regexp.MustCompile(`.*=\s*\d*\s*\d*\s*(\d*)\s*([a-zA-Z0-9-.]*)`)
 
-type SRVRecord struct {
+type srvRecord struct {
 	port       int32
 	domainName string
 }
 
-func parseSRVRecords(str string) []SRVRecord {
-	var recs []SRVRecord
+func parseSRVRecords(str string) []srvRecord {
+	var recs []srvRecord
 
 	matches := srvRecordRegEx.FindAllStringSubmatch(str, -1)
 	for i := range matches {
 		// First match at index 0 is the full text that was matched; index 1 is the port and index 2 is the domain name.
 		port, _ := strconv.ParseInt(matches[i][1], 10, 32)
-		recs = append(recs, SRVRecord{
+		recs = append(recs, srvRecord{
 			port:       int32(port),
 			domainName: matches[i][2],
 		})

--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -58,6 +58,7 @@ var (
 	ctx                              = context.TODO()
 )
 
+// TestConformance runs the conformance test.
 func TestConformance(t *testing.T) {
 	RegisterFailHandler(Fail)
 	RunSpecs(t, "Conformance Suite")

--- a/conformance/endpoint_slice.go
+++ b/conformance/endpoint_slice.go
@@ -30,6 +30,7 @@ import (
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 )
 
+// K8sEndpointSliceManagedByName is the name used for endpoint slices managed by the Kubernetes controller
 const K8sEndpointSliceManagedByName = "endpointslice-controller.k8s.io"
 
 var _ = Describe("", Label(OptionalLabel, EndpointSliceLabel), func() {

--- a/conformance/framework.go
+++ b/conformance/framework.go
@@ -19,88 +19,14 @@ package conformance
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"time"
 
-	. "github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/kubernetes/scheme"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/remotecommand"
 )
-
-type (
-	DoOperationFunc func() (interface{}, error)
-	CheckResultFunc func(result interface{}) (bool, string, error)
-)
-
-// AwaitUntil periodically performs the given operation until the given CheckResultFunc returns true, an error, or a
-// timeout is reached.
-func AwaitUntil(opMsg string, doOperation DoOperationFunc, checkResult CheckResultFunc) interface{} {
-	result, errMsg, err := AwaitResultOrError(opMsg, doOperation, checkResult)
-	Expect(err).NotTo(HaveOccurred(), errMsg)
-
-	return result
-}
-
-func AwaitResultOrError(opMsg string, doOperation DoOperationFunc, checkResult CheckResultFunc) (interface{}, string, error) {
-	var finalResult interface{}
-	var lastMsg string
-
-	err := wait.PollUntilContextTimeout(context.Background(), 500*time.Millisecond,
-		10*time.Second, true, func(_ context.Context) (bool, error) {
-			result, err := doOperation()
-			if err != nil {
-				if IsTransientError(err, opMsg) {
-					return false, nil
-				}
-				return false, err
-			}
-
-			ok, msg, err := checkResult(result)
-			if err != nil {
-				return false, err
-			}
-
-			if ok {
-				finalResult = result
-				return true, nil
-			}
-
-			lastMsg = msg
-			return false, nil
-		})
-
-	errMsg := ""
-	if err != nil {
-		errMsg = "Failed to " + opMsg
-		if lastMsg != "" {
-			errMsg += ". " + lastMsg
-		}
-	}
-
-	return finalResult, errMsg, err
-}
-
-// identify API errors which could be considered transient/recoverable
-// due to server state.
-func IsTransientError(err error, opMsg string) bool {
-	if errors.IsInternalError(err) ||
-		errors.IsServerTimeout(err) ||
-		errors.IsTimeout(err) ||
-		errors.IsServiceUnavailable(err) ||
-		errors.IsUnexpectedServerError(err) ||
-		errors.IsTooManyRequests(err) {
-		fmt.Fprintf(GinkgoWriter, "Transient failure when attempting to %s: %v", opMsg, err)
-		return true
-	}
-
-	return false
-}
 
 func execCmd(k8s kubernetes.Interface, config *rest.Config, podName string, podNamespace string, command []string) ([]byte, []byte, error) {
 	req := k8s.CoreV1().RESTClient().Post().Resource("pods").Name(podName).Namespace(podNamespace).SubResource("exec")

--- a/conformance/report.go
+++ b/conformance/report.go
@@ -17,7 +17,7 @@ limitations under the License.
 package conformance
 
 import (
-	_ "embed"
+	_ "embed" // Needed for go:embed
 	"errors"
 	"fmt"
 	"html/template"


### PR DESCRIPTION
The switch to the tools module for tool dependency tracking broke verify-golint.sh (golint was run from tools by "go -C tools" but the packages were no longer accessible).

This fixes the above by converting the packages to relative references.

It also ensures that output sent to stderr is not ignored, so that future errors of this type don't go undetected. It also ignores the golint error about OptionalLabel; documenting that isn't very useful.

Other commits fix the linting errors that previously went undetected.

Fixes: #74