### PR TITLE
Add connectivity conformance test involving service in two clusters

### DIFF
--- a/conformance/clusterip_service_dns.go
+++ b/conformance/clusterip_service_dns.go
@@ -58,10 +58,7 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 		for _, client := range clients {
 			By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
 
-			Eventually(func() string {
-				stdout, _, _ := execCmd(client.k8s, client.rest, t.requestPod.Name, t.namespace, command)
-				return string(stdout)
-			}, 20, 1).Should(ContainSubstring(clusterSetIP), reportNonConformant(""))
+			t.awaitCmdOutputContains(&client, command, clusterSetIP, 1, reportNonConformant(""))
 		}
 	})
 
@@ -107,10 +104,7 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 
 		By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), clients[0].name))
 
-		Eventually(func() string {
-			stdout, _, _ := execCmd(clients[0].k8s, clients[0].rest, t.requestPod.Name, t.namespace, command)
-			return string(stdout)
-		}, 20, 1).Should(ContainSubstring(resolvedIP), reportNonConformant(""))
+		t.awaitCmdOutputContains(&clients[0], command, resolvedIP, 1, reportNonConformant(""))
 	})
 })
 
@@ -122,9 +116,7 @@ func (t *testDriver) expectSRVRecords(c *clusterClients, domainName string) []SR
 	var srvRecs []SRVRecord
 
 	Eventually(func() []SRVRecord {
-		stdout, _, _ := execCmd(c.k8s, c.rest, t.requestPod.Name, t.namespace, command)
-		srvRecs = parseSRVRecords(string(stdout))
-
+		srvRecs = parseSRVRecords(t.execCmdOnRequestPod(c, command))
 		return srvRecs
 	}, 20, 1).ShouldNot(BeEmpty(), reportNonConformant(""))
 

--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -276,6 +276,18 @@ func (t *testDriver) startRequestPod(ctx context.Context, client clusterClients)
 	}, 20, 1).Should(Succeed())
 }
 
+func (t *testDriver) execCmdOnRequestPod(c *clusterClients, command []string) string {
+	stdout, _, _ := execCmd(c.k8s, c.rest, t.requestPod.Name, t.namespace, command)
+	return string(stdout)
+}
+
+func (t *testDriver) awaitCmdOutputContains(c *clusterClients, command []string, expectedString string, nIter int, msg func() string) {
+	Eventually(func(g Gomega) {
+		output := t.execCmdOnRequestPod(c, command)
+		g.Expect(output).To(ContainSubstring(expectedString), "Command output")
+	}).Within(time.Duration(20*int64(nIter))*time.Second).ProbeEvery(time.Second).MustPassRepeatedly(nIter).Should(Succeed(), msg)
+}
+
 func toMCSPorts(from []corev1.ServicePort) []v1alpha1.ServicePort {
 	var mcsPorts []v1alpha1.ServicePort
 

--- a/conformance/connectivity.go
+++ b/conformance/connectivity.go
@@ -17,17 +17,19 @@ limitations under the License.
 package conformance
 
 import (
+	"context"
 	"fmt"
 	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-var _ = Describe("Connectivity to remote services", func() {
+var _ = Describe("", func() {
 	t := newTestDriver()
 
-	Context("with no exported service", func() {
+	Context("Connectivity to a service that is not exported", func() {
 		It("should be inaccessible", Label(RequiredLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#exporting-services")
 			By("attempting to access the remote service", func() {
@@ -47,25 +49,70 @@ var _ = Describe("Connectivity to remote services", func() {
 		})
 	})
 
-	Context("with an exported ClusterIP service", func() {
-		It("should be accessible through DNS (after a potential delay)", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel), func() {
+	Context("Connectivity to an exported ClusterIP service", func() {
+		It("should be accessible through DNS", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
-			By("exporting the service", func() {
+			By("Exporting the service", func() {
 				// On the "remote" cluster
 				t.createServiceExport(&clients[0])
 			})
-			By("issuing a request from all clusters", func() {
+			By("Issuing a request from all clusters", func() {
 				// Run on all clusters
 				command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42",
 					t.helloService.Name, t.namespace)}
 
-				// Run on all clusters
 				for _, client := range clients {
 					By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
 
 					t.awaitCmdOutputContains(&client, command, "pod ip", 1, reportNonConformant(""))
 				}
 			})
+		})
+	})
+
+	Context("Connectivity to a ClusterIP service existing in two clusters but exported from one", func() {
+		BeforeEach(func() {
+			requireTwoClusters()
+		})
+
+		JustBeforeEach(func() {
+			t.deployHelloService(&clients[1], newHelloService())
+		})
+
+		It("should only access the exporting cluster", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel), func() {
+			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#exporting-services")
+
+			By(fmt.Sprintf("Exporting the service on cluster %q", clients[0].name))
+
+			t.createServiceExport(&clients[0])
+
+			By(fmt.Sprintf("Awaiting service deployment pod IP on cluster %q", clients[0].name))
+
+			servicePodIP := ""
+
+			Eventually(func() string {
+				pods, err := clients[0].k8s.CoreV1().Pods(t.namespace).List(context.TODO(), metav1.ListOptions{
+					LabelSelector: metav1.FormatLabelSelector(newHelloDeployment().Spec.Selector),
+				})
+				Expect(err).ToNot(HaveOccurred())
+
+				if len(pods.Items) > 0 {
+					servicePodIP = pods.Items[0].Status.PodIP
+				}
+
+				return servicePodIP
+			}, 20, 1).ShouldNot(BeEmpty(), "Service deployment pod was not allocated an IP")
+
+			By(fmt.Sprintf("Retrieved service deployment pod IP %q", servicePodIP))
+
+			command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42",
+				t.helloService.Name, t.namespace)}
+
+			for _, client := range clients {
+				By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
+
+				t.awaitCmdOutputContains(&client, command, servicePodIP, 10, reportNonConformant(""))
+			}
 		})
 	})
 })


### PR DESCRIPTION
...as described in https://github.com/kubernetes-sigs/mcs-api/issues/65:
    
"_If a ServiceExport exists on cluster A, and not on cluster B, and the corresponding service exists on both, remote clusters only access cluster A, never cluster B_"

The first commit improves the error reporting when verifying command exec output. See commit message for details.
