### PR TITLE
conformance: fix annotations/labels test to not be exact match

### DIFF
--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -38,6 +38,17 @@ var _ = Describe("", func() {
 		t.createServiceExport(&clients[0], helloServiceExport)
 	})
 
+	assertHasKeyValues := func(actual, expected map[string]string) {
+		for k, v := range expected {
+			Expect(actual).To(HaveKeyWithValue(k, v), reportNonConformant(""))
+		}
+	}
+	assertNotHasKeyValues := func(actual, expected map[string]string) {
+		for k, v := range expected {
+			Expect(actual).ToNot(HaveKeyWithValue(k, v), reportNonConformant(""))
+		}
+	}
+
 	Specify("Exporting a ClusterIP service should create a ServiceImport of type ClusterSetIP in the service's namespace in each cluster. "+
 		"Unexporting should delete the ServiceImport",
 		Label(RequiredLabel), func() {
@@ -231,8 +242,11 @@ var _ = Describe("", func() {
 					})
 					Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
 
-					Expect(serviceImport.Annotations).To(Equal(helloServiceExport.Spec.ExportedAnnotations), reportNonConformant(""))
-					Expect(serviceImport.Labels).To(Equal(helloServiceExport.Spec.ExportedLabels), reportNonConformant(""))
+					assertHasKeyValues(serviceImport.Annotations, helloServiceExport.Annotations)
+					assertNotHasKeyValues(serviceImport.Annotations, helloServiceExport2.Annotations)
+
+					assertHasKeyValues(serviceImport.Labels, helloServiceExport.Labels)
+					assertNotHasKeyValues(serviceImport.Labels, helloServiceExport2.Labels)
 				})
 		})
 	})
@@ -252,8 +266,8 @@ var _ = Describe("", func() {
 				})
 				Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
 
-				Expect(serviceImport.Annotations).To(Equal(helloServiceExport.Spec.ExportedAnnotations), reportNonConformant(""))
-				Expect(serviceImport.Labels).To(Equal(helloServiceExport.Spec.ExportedLabels), reportNonConformant(""))
+				assertHasKeyValues(serviceImport.Annotations, helloServiceExport.Annotations)
+				assertHasKeyValues(serviceImport.Labels, helloServiceExport.Labels)
 			})
 	})
 })


### PR DESCRIPTION
This relax the test since the spec about annotations/labels sync does say that labels/annotations should not be taken from the Service exported but it doesn't says that those should be the only annotation/labels ever present on the ServiceImport object. For instance in Cilium we use this annotation: https://github.com/kubernetes-sigs/mcs-api/blob/fede3192824f8c9d44719a467528f9438ae6007b/pkg/controllers/common.go#L35.