### PR TITLE
Update go to 1.23 and coredns to 1.11.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.22 as builder
+FROM golang:1.23 as builder
 
 WORKDIR /workspace
 # Copy the Go Modules manifests

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module sigs.k8s.io/mcs-api
 
-go 1.22.0
-
-toolchain go1.22.3
+go 1.23.0
 
 require (
 	github.com/go-logr/logr v1.4.1

--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -39,7 +39,7 @@ if [ ! -z "${BUILD_CONTROLLER}" ] || [ -z "$(docker images mcs-api-controller -q
   popd
 fi
 
-coredns_version="1.11.1"
+coredns_version="1.11.4"
 coredns_image="multicluster/coredns:latest"
 coredns_path="/tmp/coredns-${coredns_version}"
 if [ ! -d "${coredns_path}" ]; then

--- a/tools/go.mod
+++ b/tools/go.mod
@@ -1,6 +1,6 @@
 module github.com/kubernetes-sigs/mcs-api/tools
 
-go 1.22.4
+go 1.23.0
 
 require (
 	golang.org/x/lint v0.0.0-20210508222113-6edffad5e616


### PR DESCRIPTION
With the recent updates I made to the coredns plugin it now seems to require go 1.23 so update everything to go 1.23 and also update the coredns version so that we can build the multicluster plugin again