### PR TITLE
controllers: fix ServiceReconciler headless service reconciliation

### DIFF
--- a/pkg/controllers/service.go
+++ b/pkg/controllers/service.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
@@ -64,11 +65,15 @@ func (r *ServiceReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return ctrl.Result{}, err
 	}
 
-	if len(svcImport.Spec.IPs) > 0 {
+	desiredIPs := []string{service.Spec.ClusterIP}
+	if service.Spec.ClusterIP == v1.ClusterIPNone {
+		desiredIPs = []string{}
+	}
+	if slices.Equal(desiredIPs, svcImport.Spec.IPs) {
 		return ctrl.Result{}, nil
 	}
 
-	svcImport.Spec.IPs = []string{service.Spec.ClusterIP}
+	svcImport.Spec.IPs = desiredIPs
 	if err := r.Client.Update(ctx, &svcImport); err != nil {
 		return ctrl.Result{}, err
 	}


### PR DESCRIPTION
Headless services should have an empty list of IPs instead of a list containing the "None" string.