### PR TITLE
Conformance: verify ServiceImport doesn't contain Service labels/annotations

### DIFF
--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -113,7 +113,10 @@ func testGeneralServiceImport() {
 				Expect(serviceImport).NotTo(BeNil(), "ServiceImport was not found")
 
 				assertHasKeyValues(serviceImport.Annotations, helloServiceExport.Annotations)
+				assertNotHasKeyValues(serviceImport.Annotations, t.helloService.Annotations)
+
 				assertHasKeyValues(serviceImport.Labels, helloServiceExport.Labels)
+				assertNotHasKeyValues(serviceImport.Labels, t.helloService.Labels)
 			})
 	})
 


### PR DESCRIPTION
...since labels/annotations should only be taken from the ServiceExport.