### PR TITLE
Bump to coredns 1.11.4 for the multicluster plugin

### DIFF
--- a/scripts/up.sh
+++ b/scripts/up.sh
@@ -39,7 +39,7 @@ if [ ! -z "${BUILD_CONTROLLER}" ] || [ -z "$(docker images mcs-api-controller -q
   popd
 fi
 
-coredns_version="1.11.1"
+coredns_version="1.11.4"
 coredns_image="multicluster/coredns:latest"
 coredns_path="/tmp/coredns-${coredns_version}"
 if [ ! -d "${coredns_path}" ]; then


### PR DESCRIPTION
The multicluster plugin requires 1.11.4. This remains fragile since the container build will always pick up the latest multicluster plugin...