### PR TITLE
apis: add short names to crds

### DIFF
--- a/config/crd-base/multicluster.x-k8s.io_serviceexports.yaml
+++ b/config/crd-base/multicluster.x-k8s.io_serviceexports.yaml
@@ -24,6 +24,7 @@ spec:
     kind: ServiceExport
     shortNames:
     - svcex
+    - svcexport
   versions:
   - name: v1alpha1
     served: true

--- a/config/crd-base/multicluster.x-k8s.io_serviceimports.yaml
+++ b/config/crd-base/multicluster.x-k8s.io_serviceimports.yaml
@@ -24,6 +24,7 @@ spec:
     kind: ServiceImport
     shortNames:
     - svcim
+    - svcimport
   versions:
   - name: v1alpha1
     served: true

--- a/config/crd/multicluster.x-k8s.io_serviceexports.yaml
+++ b/config/crd/multicluster.x-k8s.io_serviceexports.yaml
@@ -24,6 +24,7 @@ spec:
     kind: ServiceExport
     shortNames:
       - svcex
+      - svcexport
   versions:
     - name: v1alpha1
       served: true

--- a/config/crd/multicluster.x-k8s.io_serviceimports.yaml
+++ b/config/crd/multicluster.x-k8s.io_serviceimports.yaml
@@ -24,6 +24,7 @@ spec:
     kind: ServiceImport
     shortNames:
       - svcim
+      - svcimport
   versions:
     - name: v1alpha1
       served: true

--- a/pkg/apis/v1alpha1/serviceexport.go
+++ b/pkg/apis/v1alpha1/serviceexport.go
@@ -22,6 +22,7 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName={svcex,svcexport}
 
 // ServiceExport declares that the Service with the same name and namespace
 // as this export should be consumable from other clusters.

--- a/pkg/apis/v1alpha1/serviceimport.go
+++ b/pkg/apis/v1alpha1/serviceimport.go
@@ -23,6 +23,7 @@ import (
 
 // +genclient
 // +kubebuilder:object:root=true
+// +kubebuilder:resource:shortName={svcim,svcimport}
 
 // ServiceImport describes a service imported from clusters in a ClusterSet.
 type ServiceImport struct {


### PR DESCRIPTION
Add svcexport/svcimport short name that might feel more natural to type as the short name of service is svc. Also preserve the existing default short name "svcex" and "svcim".