### PR TITLE
Add SIG-Multicluster reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,7 +1,20 @@
 # See the OWNERS docs at https://go.k8s.io/owners
 
-approvers:
-  - JeremyOT
-  - pmorie
+reviewers:
+  - jeremyot
   - lauralorenz
   - skitt
+  - corentone
+  - jnpacker
+  - MrFreezeex
+  - munnerz
+  - RainbowMango
+  - ryanzhang-oss
+
+approvers:
+  - JeremyOT
+  - lauralorenz
+  - skitt
+
+emeritus_approvers:
+  - pmorie


### PR DESCRIPTION
We're adding a group of reviewers to help with SIG-MC PR reviews.

This also moves pmorie to emeritus, as has been done elsewhere in SIG-MC (thanks Paul!).