### PR TITLE
Add embed and new const name to facilitate CRD install in go

### DIFF
--- a/config/crd/embed.go
+++ b/config/crd/embed.go
@@ -1,0 +1,28 @@
+/*
+Copyright 2025 The Kubernetes Authors.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package crd
+
+import _ "embed" // import embed to be able to use go:embed
+
+var (
+	// ServiceExportCRD is the embedded YAML for the ServiceExport CRD
+	//go:embed multicluster.x-k8s.io_serviceexports.yaml
+	ServiceExportCRD []byte
+	// ServiceImportCRD is the embedded YAML for the ServiceImport CRD
+	//go:embed multicluster.x-k8s.io_serviceimports.yaml
+	ServiceImportCRD []byte
+)

--- a/pkg/apis/v1alpha1/serviceexport.go
+++ b/pkg/apis/v1alpha1/serviceexport.go
@@ -20,6 +20,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// ServiceExportPluralName is the plural name of ServiceExport
+	ServiceExportPluralName = "serviceexports"
+	// ServiceExportKindName is the kind name of ServiceExport
+	ServiceExportKindName = "ServiceExport"
+	// ServiceExportFullName is the full name of ServiceExport
+	ServiceExportFullName = ServiceExportPluralName + "." + GroupName
+)
+
+// ServiceExportVersionedName is the versioned name of ServiceExport
+var ServiceExportVersionedName = ServiceExportKindName + "/" + GroupVersion.Version
+
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName={svcex,svcexport}

--- a/pkg/apis/v1alpha1/serviceimport.go
+++ b/pkg/apis/v1alpha1/serviceimport.go
@@ -21,6 +21,18 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+const (
+	// ServiceImportPluralName is the plural name of ServiceImport
+	ServiceImportPluralName = "serviceimports"
+	// ServiceImportKindName is the kind name of ServiceImport
+	ServiceImportKindName = "ServiceImport"
+	// ServiceImportFullName is the full name of ServiceImport
+	ServiceImportFullName = ServiceImportPluralName + "." + GroupName
+)
+
+// ServiceImportVersionedName is the versioned name of ServiceImport
+var ServiceImportVersionedName = ServiceImportKindName + "/" + GroupVersion.Version
+
 // +genclient
 // +kubebuilder:object:root=true
 // +kubebuilder:resource:shortName={svcim,svcimport}


### PR DESCRIPTION
In Cilium, we are installing the Cilium specific CRDs via our operator. We don't do that so far for MCS-API CRDs and let user do it manually as we also do that for GW-API CRDs. But unlike GW-API, MCS only support one clusterset/one implementation of MCS per cluster so it would makes sense that we install MCS CRDs like the rest of our CRDs which would be more straightforward for our users.

This PR essentially add the bits required for us to manage CRD via go code meaning:
- Embedding the yaml CRDs in go symbol that we could use in Cilium (-> would be super useful as we can just import via go and not have extra automation to download the CRD or something like that)
- New symbol for the CRDs names (-> would be handy for us to reference the CRD in our logic that create/update CRD + we would be able to use some of those const elsewhere in some MCS related code) 