### PR TITLE
Increase artificial delay for 2 cluster conformance tests

### DIFF
--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -349,9 +349,9 @@ func newTwoClusterTestDriver(t *testDriver) *twoClusterTestDriver {
 	})
 
 	JustBeforeEach(func() {
-		// Sleep a little before deploying on the second cluster to ensure the first cluster's ServiceExport timestamp
-		// is older so conflict checking is deterministic.
-		time.Sleep(100 * time.Millisecond)
+		// Delay a little before deploying on the second cluster to ensure the first cluster's ServiceExport timestamp
+		// is older so conflict checking is deterministic. Make the delay at least 1 sec as creation timestamps have seconds granularity.
+		time.Sleep(1100 * time.Millisecond)
 
 		t.deployHelloService(&clients[1], tt.helloService2)
 		t.createServiceExport(&clients[1], tt.helloServiceExport2)


### PR DESCRIPTION
It delays a bit in between exporting the services so the timestamps differ to make conflict checking deterministic. However 100 ms is too short as creation timestamps have seconds granularity so increase the delay to at least 1 sec.