### PR TITLE
Log general steps in the conformance tests

### DIFF
--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -197,11 +197,15 @@ func (t *testDriver) createServiceExport(c *clusterClients, serviceExport *v1alp
 	_, err := c.mcs.MulticlusterV1alpha1().ServiceExports(t.namespace).Create(
 		ctx, serviceExport, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("Service \"%s/%s\" exported on cluster %q", t.namespace, helloServiceName, c.name))
 }
 
 func (t *testDriver) deleteServiceExport(c *clusterClients) {
 	Expect(c.mcs.MulticlusterV1alpha1().ServiceExports(t.namespace).Delete(ctx, helloServiceName,
 		metav1.DeleteOptions{})).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("Service \"%s/%s\" unexported on cluster %q", t.namespace, helloServiceName, c.name))
 }
 
 func (t *testDriver) deployHelloService(c *clusterClients, service *corev1.Service) {
@@ -210,8 +214,10 @@ func (t *testDriver) deployHelloService(c *clusterClients, service *corev1.Servi
 		Expect(err).ToNot(HaveOccurred())
 	}
 
-	_, err := c.k8s.CoreV1().Services(t.namespace).Create(ctx, service, metav1.CreateOptions{})
+	deployed, err := c.k8s.CoreV1().Services(t.namespace).Create(ctx, service, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
+
+	By(fmt.Sprintf("Service \"%s/%s\" deployed on cluster %q", deployed.Namespace, deployed.Name, c.name))
 }
 
 func (t *testDriver) getServiceImport(c *clusterClients, name string) *v1alpha1.ServiceImport {

--- a/conformance/endpoint_slice.go
+++ b/conformance/endpoint_slice.go
@@ -69,8 +69,6 @@ var _ = Describe("", Label(OptionalLabel, EndpointSliceLabel), func() {
 			}
 		}
 
-		By("Unexporting the service")
-
 		t.deleteServiceExport(&clients[0])
 
 		for i, client := range clients {

--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -82,15 +82,11 @@ func testGeneralServiceImport() {
 		t.ensureServiceImport(&clients[0], t.helloService.Name, fmt.Sprintf(
 			"the ServiceImport no longer exists after exporting on cluster %q", clients[1].name))
 
-		By(fmt.Sprintf("Unexporting the service on the first cluster %q", clients[0].name))
-
 		t.deleteServiceExport(&clients[0])
 
 		t.ensureServiceImport(&clients[0], t.helloService.Name, fmt.Sprintf(
 			"the ServiceImport no longer exists after unexporting the service on cluster %q while still exported on cluster %q",
 			clients[0].name, clients[1].name))
-
-		By(fmt.Sprintf("Unexporting the service on the second cluster %q", clients[1].name))
 
 		t.deleteServiceExport(&clients[1])
 
@@ -173,8 +169,6 @@ func testClusterIPServiceImport() {
 			Expect(serviceImport.Spec.Type).To(Equal(v1alpha1.ClusterSetIP), reportNonConformant(
 				fmt.Sprintf("ServiceImport on cluster %q has type %q", clients[i].name, serviceImport.Spec.Type)))
 		}
-
-		By("Unexporting the service")
 
 		t.deleteServiceExport(&clients[0])
 
@@ -285,8 +279,6 @@ func testHeadlessServiceImport() {
 			Expect(serviceImport.Spec.Type).To(Equal(v1alpha1.Headless), reportNonConformant(
 				fmt.Sprintf("ServiceImport on cluster %q has type %q", clients[i].name, serviceImport.Spec.Type)))
 		}
-
-		By("Unexporting the service")
 
 		t.deleteServiceExport(&clients[0])
 


### PR DESCRIPTION
Specifically, when a service is deployed, exported and unexported to help with debugging when a test fails. Of particular use is the service namespace/name, cluster name and timestamps for correlation when inspecting pod logs.