### PR TITLE
apis: conformance: add more conflict condition on asymetrical traffic

### DIFF
--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -247,8 +247,11 @@ func testClusterIPServiceImport() {
 				}
 			})
 
-			Specify("should expose the union of the constituent service ports", Label(RequiredLabel), func() {
+			Specify("should expose the union of the constituent service ports and raise a conflict", Label(RequiredLabel), func() {
 				AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port")
+
+				t.awaitServiceExportCondition(&clients[0], v1alpha1.ServiceExportConditionConflict, metav1.ConditionTrue)
+				t.awaitServiceExportCondition(&clients[1], v1alpha1.ServiceExportConditionConflict, metav1.ConditionTrue)
 
 				t.awaitServiceImport(&clients[0], t.helloService.Name, false,
 					func(g Gomega, serviceImport *v1alpha1.ServiceImport) {

--- a/pkg/apis/v1alpha1/serviceexport.go
+++ b/pkg/apis/v1alpha1/serviceexport.go
@@ -235,10 +235,8 @@ const (
 	ServiceExportConditionConflict ServiceExportConditionType = "Conflict"
 
 	// ServiceExportReasonPortConflict is used with the "Conflict" condition
-	// when the exported service has a conflict related to port configuration.
-	// This includes when ports on resulting imported services would have
-	// duplicated names (including unnamed/empty name) or duplicated
-	// port/protocol pairs.
+	// when the exported service has a conflict related to port configuration
+	// if the ports are not identical in all the constituent Services.
 	ServiceExportReasonPortConflict ServiceExportConditionReason = "PortConflict"
 
 	// ServiceExportReasonTypeConflict is used with the "Conflict" condition
@@ -272,6 +270,13 @@ const (
 	// ServiceExportReasonTrafficDistributionConflict is used with the "Conflict"
 	// condition when the exported service has a conflict related to traffic distribution.
 	ServiceExportReasonTrafficDistributionConflict ServiceExportConditionReason = "TrafficDistributionConflict"
+
+	// ServiceExportReasonIPFamilyConflict is used with the "Conflict" condition
+	// when the exported service has a conflict related to IPFamilies.
+	// The handling of IP families is implementation-specific but this condition
+	// must be used if a conflicting IP family may result in network traffic reaching
+	// only a subset of the backends depending on the IP protocol used.
+	ServiceExportReasonIPFamilyConflict ServiceExportConditionReason = "IPFamilyConflict"
 
 	// ServiceExportReasonNoConflicts is used with the "Conflict" condition
 	// when the condition is False.


### PR DESCRIPTION
This is the "implementation" of the following KEP change: https://github.com/kubernetes/enhancements/pull/5706.

It standardize the IPFamilyConflict condition which implementation may optionally use and mandate that PortConflict should be used if all ports are not identical (while not changing the union behavior).