### PR TITLE
conformance: add connectity test for conflicting ports

### DIFF
--- a/conformance/report.go
+++ b/conformance/report.go
@@ -43,6 +43,7 @@ const (
 	ExternalNameLabel        = "ExternalName"
 	EndpointSliceLabel       = "EndpointSlice"
 	ExportedLabelsLabel      = "ExportedLabels"
+	StrictPortConflictLabel  = "StrictPortConflict"
 	SpecRefReportEntry       = "spec-ref"
 	NonConformantReportEntry = "non-conformant"
 )


### PR DESCRIPTION
Extract the function to awaitServicePodIP and add two new connectivity tests with ports conflict with conflicting name and conflicting port number.

Fixes #135 