### PR TITLE
conformance: allow retries when execCmd hangs

### DIFF
--- a/conformance/framework.go
+++ b/conformance/framework.go
@@ -45,7 +45,7 @@ func execCmd(k8s kubernetes.Interface, config *rest.Config, podName string, podN
 
 	var stdout, stderr bytes.Buffer
 
-	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), 4*time.Second)
 	defer cancel()
 
 	err = exec.StreamWithContext(ctx, remotecommand.StreamOptions{


### PR DESCRIPTION
In some CI testing I got some error with the test "Connectivity to an exported ClusterIP service". I tracked it down to the fact that in this test we export the service and instantly start the connectivity test while `nc` can also hangs indefinitely in some case and since the context timeout of the command is the same as the max time in the `Within` (20s) it could essentially prevent retrying the command :(.

This commit fixes this by reducing the execCmd timeout to 4s which, with `ProbeEvery` set to 1s, should at least get at least 4 tests each time we do a command (or more if it doesn't hang for 4s on each run). We don't perform task that are supposed to be individually very long so 4s should be plenty already!