### PR TITLE
Make conformance test DNS domain configurable 

### DIFF
--- a/conformance/clusterip_service_dns.go
+++ b/conformance/clusterip_service_dns.go
@@ -32,7 +32,7 @@ import (
 var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 	t := newTestDriver()
 
-	Specify("A DNS lookup of the <service>.<ns>.svc.clusterset.local domain for a ClusterIP service should resolve to the "+
+	Specify("A DNS lookup of the <service>.<ns>.svc."+dnsDomain+" domain for a ClusterIP service should resolve to the "+
 		"clusterset IP", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
@@ -47,7 +47,7 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 			serviceImports = append(serviceImports, serviceImport)
 		}
 
-		command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.svc.clusterset.local", t.helloService.Name, t.namespace)}
+		command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)}
 		for i, client := range clients {
 			clusterSetIP := serviceImports[i].Spec.IPs[0]
 			By(fmt.Sprintf("Found ServiceImport on cluster %q with clusterset IP %q", client.name, clusterSetIP))
@@ -57,11 +57,11 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 		}
 	})
 
-	Specify("A DNS SRV query of the <service>.<ns>.svc.clusterset.local domain for a ClusterIP service should return valid SRV "+
+	Specify("A DNS SRV query of the <service>.<ns>.svc."+dnsDomain+" domain for a ClusterIP service should return valid SRV "+
 		"records", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
-		domainName := fmt.Sprintf("%s.%s.svc.clusterset.local", t.helloService.Name, t.namespace)
+		domainName := fmt.Sprintf("%s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)
 
 		for _, client := range clients {
 			srvRecs := t.expectSRVRecords(&client, domainName)

--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -56,6 +56,7 @@ var (
 	clients                          []clusterClients
 	loadingRules                     *clientcmd.ClientConfigLoadingRules
 	skipVerifyEndpointSliceManagedBy bool
+	dnsDomain                        string
 	ctx                              = context.TODO()
 )
 
@@ -76,6 +77,8 @@ func init() {
 			"However with some implementations, MCS EndpointSlices may be created and managed by K8s. If this flag is set to true, "+
 			"the test only verifies the presence of the label.",
 			discoveryv1.LabelManagedBy, K8sEndpointSliceManagedByName))
+	flag.StringVar(&dnsDomain, "dns-domain", "clusterset.local", "The DNS domain suffix used for multi-cluster services. "+
+		"The default is \"clusterset.local\" as specified by the MCS spec, but some implementations may use a custom domain.")
 }
 
 var _ = BeforeSuite(func() {
@@ -370,8 +373,8 @@ func (t *testDriver) awaitServicePodIP(c *clusterClients) string {
 }
 
 func (t *testDriver) execPortConnectivityCommand(port int, matchStr string, nIter int) {
-	command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local %d",
-		t.helloService.Name, t.namespace, port)}
+	command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.%s %d",
+		t.helloService.Name, t.namespace, dnsDomain, port)}
 
 	for _, client := range clients {
 		By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))

--- a/conformance/connectivity.go
+++ b/conformance/connectivity.go
@@ -37,8 +37,8 @@ var _ = Describe("", func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#exporting-services")
 			By("attempting to access the remote service", func() {
 				By("issuing a request from all clusters", func() {
-					command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.clusterset.local 42",
-						t.helloService.Name, t.namespace)}
+					command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.%s 42",
+						t.helloService.Name, t.namespace, dnsDomain)}
 
 					// Run on all clusters
 					for _, client := range clients {

--- a/conformance/headless_service_dns.go
+++ b/conformance/headless_service_dns.go
@@ -45,11 +45,11 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 		t.helloDeployment.Spec.Replicas = ptr.To(int32(replicas))
 	})
 
-	Specify("A DNS query of the <service>.<ns>.svc.clusterset.local domain for a headless service should return the "+
+	Specify("A DNS query of the <service>.<ns>.svc."+dnsDomain+" domain for a headless service should return the "+
 		"ready endpoint addresses of all the backing pods", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
-		command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.svc.clusterset.local", t.helloService.Name, t.namespace)}
+		command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)}
 
 		endpoints := t.awaitK8sEndpoints(&clients[0], discovery.AddressTypeIPv4)
 
@@ -75,7 +75,7 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 			Expect(err).ToNot(HaveOccurred())
 		})
 
-		Specify("A DNS query of the <hostname>.<clusterid>.<service>.<ns>.svc.clusterset.local domain for a headless StatefulSet "+
+		Specify("A DNS query of the <hostname>.<clusterid>.<service>.<ns>.svc."+dnsDomain+" domain for a headless StatefulSet "+
 			"service should return the requested pod's endpoint address", Label(EndpointSliceLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
@@ -103,8 +103,8 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 				for i := range eps.Endpoints {
 					ep := &eps.Endpoints[i]
 
-					command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.%s.%s.svc.clusterset.local",
-						ptr.Deref(ep.Hostname, ""), clusterID, t.helloService.Name, t.namespace)}
+					command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.%s.%s.svc.%s",
+						ptr.Deref(ep.Hostname, ""), clusterID, t.helloService.Name, t.namespace, dnsDomain)}
 
 					By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
 
@@ -114,13 +114,13 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 		})
 	})
 
-	Specify("A DNS SRV query of the <service>.<ns>.svc.clusterset.local domain for a headless service should return valid SRV "+
+	Specify("A DNS SRV query of the <service>.<ns>.svc."+dnsDomain+" domain for a headless service should return valid SRV "+
 		"records", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
 		endpoints := t.awaitK8sEndpoints(&clients[0], discovery.AddressTypeIPv4)
 
-		domainName := fmt.Sprintf("%s.%s.svc.clusterset.local", t.helloService.Name, t.namespace)
+		domainName := fmt.Sprintf("%s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)
 
 		for _, client := range clients {
 			srvRecs := t.expectSRVRecords(&client, domainName)

--- a/conformance/report.go
+++ b/conformance/report.go
@@ -226,9 +226,11 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 	data := struct {
 		Groups       []testGrouping
 		SuiteFailure string
+		DNSDomain    string
 	}{
 		Groups:       testGroups,
 		SuiteFailure: suiteFailure,
+		DNSDomain:    dnsDomain,
 	}
 
 	out, err := os.Create("report.html")

--- a/conformance/report_template.gohtml
+++ b/conformance/report_template.gohtml
@@ -15,6 +15,10 @@
 <body>
 <h2>MCS Conformance Report</h2>
 
+{{if and .DNSDomain (ne .DNSDomain "clusterset.local")}}
+    <p>DNS domain suffix: <strong>{{.DNSDomain}}</strong></p>
+{{end}}
+
 {{if .SuiteFailure }}
     <p style="color: red">{{.SuiteFailure}}</p>
 {{end}}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                             

  - Add `--dns-domain` flag (default: `clusterset.local`) to allow running conformance tests against MCS implementations that use a custom DNS domain
  - Replace all hardcoded `clusterset.local` references in test commands across 4 files
  - Show the custom domain in the HTML conformance report when non-default

##  Test plan

  - `go build ./...` pass
  - HTML report shows custom domain when non-default, hidden when default
  - Running the conformance test using the below command shows `custom.domain` in the test logs.
  ```bash
go -C conformance run github.com/onsi/ginkgo/v2/ginkgo . -- \
    --kubeconfig=$HOME/.kube/config \
    --contexts=kind-c1,kind-c2 \
    --dns-domain=custom.domain
```
