### PR TITLE
Conformance: add IPv6 and dual-stack support

### DIFF
--- a/conformance/clusterip_service_dns.go
+++ b/conformance/clusterip_service_dns.go
@@ -36,24 +36,24 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 		"clusterset IP", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
-		By("Retrieving ServiceImport")
-
-		serviceImports := []*v1alpha1.ServiceImport{}
 		for _, client := range clients {
 			serviceImport := t.awaitServiceImport(&client, t.helloService.Name, false,
 				func(g Gomega, serviceImport *v1alpha1.ServiceImport) {
 					g.Expect(serviceImport.Spec.IPs).ToNot(BeEmpty(), "ServiceImport on cluster %q does not contain an IP", client.name)
 				})
-			serviceImports = append(serviceImports, serviceImport)
-		}
 
-		command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)}
-		for i, client := range clients {
-			clusterSetIP := serviceImports[i].Spec.IPs[0]
-			By(fmt.Sprintf("Found ServiceImport on cluster %q with clusterset IP %q", client.name, clusterSetIP))
-			By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
+			By(fmt.Sprintf("Found ServiceImport on cluster %q with clusterset IPs %v",
+				client.name, strings.Join(serviceImport.Spec.IPs, ",")))
 
-			t.awaitCmdOutputMatches(&client, command, clusterSetIP, 1, reportNonConformant(""))
+			for _, clusterSetIP := range serviceImport.Spec.IPs {
+				command := []string{"sh", "-c", fmt.Sprintf("nslookup -type=%s %s.%s.svc.%s.",
+					dnsRecordTypeOf(ipFamilyOf(clusterSetIP)), t.helloService.Name, t.namespace, dnsDomain)}
+
+				By(fmt.Sprintf("Executing %s command %q on cluster %q", ipFamilyOf(clusterSetIP),
+					strings.Join(command, " "), client.name))
+
+				t.awaitCmdOutputMatches(&client, command, clusterSetIP, 1, reportNonConformant(""))
+			}
 		}
 	})
 
@@ -64,12 +64,12 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 		domainName := fmt.Sprintf("%s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)
 
 		for _, client := range clients {
-			srvRecs := t.expectSRVRecords(&client, domainName)
-
 			expSRVRecs := []srvRecord{{
 				port:       t.helloService.Spec.Ports[0].Port,
 				domainName: domainName,
 			}}
+
+			srvRecs := t.expectSRVRecords(&client, domainName, len(expSRVRecs))
 
 			Expect(srvRecs).To(Equal(expSRVRecs), reportNonConformant(
 				fmt.Sprintf("Received SRV records %v do not match the expected records %v", srvRecs, expSRVRecs)))
@@ -95,7 +95,9 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 
 		By(fmt.Sprintf("Found local Service cluster IP %q", resolvedIP))
 
-		command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.svc.cluster.local", t.helloService.Name, t.namespace)}
+		// Add trailing dot to prevent search domain from being appended
+		command := []string{"sh", "-c", fmt.Sprintf("nslookup -type=%s %s.%s.svc.cluster.local.",
+			dnsRecordTypeOf(ipFamilyOf(resolvedIP)), t.helloService.Name, t.namespace)}
 
 		By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), clients[0].name))
 
@@ -103,17 +105,19 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 	})
 })
 
-func (t *testDriver) expectSRVRecords(c *clusterClients, domainName string) []srvRecord {
-	command := []string{"sh", "-c", "nslookup -type=SRV " + domainName}
+func (t *testDriver) expectSRVRecords(c *clusterClients, domainName string, expectedCount int) []srvRecord {
+	// Add trailing dot to prevent search domain from being appended
+	command := []string{"sh", "-c", "nslookup -type=SRV " + domainName + "."}
 
 	By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), c.name))
 
 	var srvRecs []srvRecord
 
-	Eventually(func() []srvRecord {
+	Eventually(func(g Gomega) {
 		srvRecs = parseSRVRecords(t.execCmdOnRequestPod(c, command))
-		return srvRecs
-	}, 20, 1).ShouldNot(BeEmpty(), reportNonConformant(""))
+		g.Expect(srvRecs).To(HaveLen(expectedCount),
+			fmt.Sprintf("Expected %d SRV records but got %d: %v", expectedCount, len(srvRecs), srvRecs))
+	}, 20, 1).Should(Succeed(), reportNonConformant(""))
 
 	return srvRecs
 }
@@ -141,9 +145,12 @@ func parseSRVRecords(str string) []srvRecord {
 	for i := range matches {
 		// First match at index 0 is the full text that was matched; index 1 is the port and index 2 is the domain name.
 		port, _ := strconv.ParseInt(matches[i][1], 10, 32)
+		domainName := matches[i][2]
+		// Strip trailing period from FQDN (some nslookup versions include it)
+		domainName = strings.TrimSuffix(domainName, ".")
 		recs = append(recs, srvRecord{
 			port:       int32(port),
-			domainName: matches[i][2],
+			domainName: domainName,
 		})
 	}
 

--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -40,6 +40,7 @@ import (
 	"k8s.io/client-go/kubernetes"
 	rest "k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
+	k8snet "k8s.io/utils/net"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1alpha1"
 	mcsclient "sigs.k8s.io/mcs-api/pkg/client/clientset/versioned"
 )
@@ -179,7 +180,7 @@ func newTestDriver() *testDriver {
 		}
 
 		// Set up the remote service (the first cluster is considered to be the remote)
-		t.deployHelloService(&clients[0], t.helloService)
+		t.helloService = t.deployHelloService(&clients[0], t.helloService)
 
 		// Start the request pod on all clusters
 		for _, client := range clients {
@@ -219,7 +220,7 @@ func (t *testDriver) deleteServiceExport(c *clusterClients) {
 	By(fmt.Sprintf("Service \"%s/%s\" unexported on cluster %q", t.namespace, helloServiceName, c.name))
 }
 
-func (t *testDriver) deployHelloService(c *clusterClients, service *corev1.Service) {
+func (t *testDriver) deployHelloService(c *clusterClients, service *corev1.Service) *corev1.Service {
 	if t.helloDeployment != nil {
 		_, err := c.k8s.AppsV1().Deployments(t.namespace).Create(ctx, t.helloDeployment, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -228,7 +229,10 @@ func (t *testDriver) deployHelloService(c *clusterClients, service *corev1.Servi
 	deployed, err := c.k8s.CoreV1().Services(t.namespace).Create(ctx, service, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
 
-	By(fmt.Sprintf("Service \"%s/%s\" deployed on cluster %q", deployed.Namespace, deployed.Name, c.name))
+	By(fmt.Sprintf("Service \"%s/%s\" with IP families %v deployed on cluster %q", deployed.Namespace, deployed.Name,
+		deployed.Spec.IPFamilies, c.name))
+
+	return deployed
 }
 
 func (t *testDriver) getServiceImport(c *clusterClients, name string) *v1alpha1.ServiceImport {
@@ -246,6 +250,8 @@ func (t *testDriver) getServiceImport(c *clusterClients, name string) *v1alpha1.
 func (t *testDriver) awaitServiceImport(c *clusterClients, name string, reportNonConformanceOnMissing bool,
 	verify func(Gomega, *v1alpha1.ServiceImport)) *v1alpha1.ServiceImport {
 	var serviceImport *v1alpha1.ServiceImport
+
+	By(fmt.Sprintf("Retrieving ServiceImport for %q on cluster %q", name, c.name))
 
 	Eventually(func(g Gomega) {
 		si := t.getServiceImport(c, name)
@@ -270,6 +276,16 @@ func (t *testDriver) awaitServiceImport(c *clusterClients, name string, reportNo
 	}).Within(20 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 	return serviceImport
+}
+
+func (t *testDriver) awaitServiceImportIPFamilies(c *clusterClients) []corev1.IPFamily {
+	serviceImport := t.awaitServiceImport(c, t.helloService.Name, false,
+		func(g Gomega, serviceImport *v1alpha1.ServiceImport) {
+			g.Expect(serviceImport.Spec.IPFamilies).NotTo(BeEmpty(),
+				"ServiceImport on cluster %q does not contain an IP family", c.name)
+		})
+
+	return serviceImport.Spec.IPFamilies
 }
 
 func (t *testDriver) awaitNoServiceImport(c *clusterClients, name, nonConformanceMsg string) {
@@ -373,13 +389,15 @@ func (t *testDriver) awaitServicePodIP(c *clusterClients) string {
 }
 
 func (t *testDriver) execPortConnectivityCommand(port int, matchStr string, nIter int) {
-	command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.%s %d",
-		t.helloService.Name, t.namespace, dnsDomain, port)}
-
 	for _, client := range clients {
-		By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
+		for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
+			serviceFQDN := fmt.Sprintf("%s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)
+			command := []string{"sh", "-c", ncCommand(ipFamily, serviceFQDN, port)}
 
-		t.awaitCmdOutputMatches(&client, command, matchStr, nIter, reportNonConformant(""))
+			By(fmt.Sprintf("Executing %s command %q on cluster %q", ipFamily, strings.Join(command, " "), client.name))
+
+			t.awaitCmdOutputMatches(&client, command, matchStr, nIter, reportNonConformant(""))
+		}
 	}
 }
 
@@ -448,4 +466,53 @@ func requireTwoClusters() {
 	if len(clients) < 2 {
 		Skip("This test requires at least 2 clusters - skipping")
 	}
+}
+
+func addressTypeOf(f corev1.IPFamily) discoveryv1.AddressType {
+	if f == corev1.IPv4Protocol {
+		return discoveryv1.AddressTypeIPv4
+	}
+
+	return discoveryv1.AddressTypeIPv6
+}
+
+func dnsRecordTypeOf(f corev1.IPFamily) string {
+	if f == corev1.IPv4Protocol {
+		return "A"
+	}
+
+	return "AAAA"
+}
+
+func ipFamilyOf(ip string) corev1.IPFamily {
+	f := k8snet.IPFamilyOfString(ip)
+	Expect(f).NotTo(Equal(k8snet.IPFamilyUnknown))
+
+	if f == k8snet.IPv4 {
+		return corev1.IPv4Protocol
+	}
+
+	return corev1.IPv6Protocol
+}
+
+// ncCommand creates a shell command that connects to a service using nc with the specified IP family.
+// The netshoot image provides nc which supports -4/-6 flags for forcing IP family.
+func ncCommand(ipFamily corev1.IPFamily, serviceFQDN string, port int) string {
+	ipFlag := "-4"
+	if ipFamily == corev1.IPv6Protocol {
+		ipFlag = "-6"
+	}
+
+	// For IPv6, nc -6 with hostname seems to hang in IPv6-only environments
+	// Fall back to explicit DNS resolution and pass IP directly to nc
+	if ipFamily == corev1.IPv6Protocol {
+		fqdnWithDot := serviceFQDN + "."
+		return fmt.Sprintf(
+			"addr=$(nslookup -type=AAAA %s 2>&1 | grep '^Address:' | grep -v '#' | tail -1 | awk '{print $2}'); "+
+				"if [ -z \"$addr\" ]; then echo 'No IPv6 address found'; exit 1; fi; "+
+				"echo hi | nc -v -w 2 $addr %d 2>&1",
+			fqdnWithDot, port)
+	}
+
+	return fmt.Sprintf("echo hi | nc -v -w 2 %s %s %d 2>&1", ipFlag, serviceFQDN, port)
 }

--- a/conformance/connectivity.go
+++ b/conformance/connectivity.go
@@ -37,14 +37,18 @@ var _ = Describe("", func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#exporting-services")
 			By("attempting to access the remote service", func() {
 				By("issuing a request from all clusters", func() {
-					command := []string{"sh", "-c", fmt.Sprintf("echo hi | nc %s.%s.svc.%s 42",
-						t.helloService.Name, t.namespace, dnsDomain)}
+					serviceFQDN := fmt.Sprintf("%s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)
 
-					// Run on all clusters
-					for _, client := range clients {
-						// Repeat multiple times
-						for i := 0; i < 20; i++ {
-							Expect(t.execCmdOnRequestPod(&client, command)).NotTo(ContainSubstring("pod ip"), reportNonConformant(""))
+					// Test all IP families for completeness
+					for _, ipFamily := range t.helloService.Spec.IPFamilies {
+						command := []string{"sh", "-c", ncCommand(ipFamily, serviceFQDN, 42)}
+
+						// Run on all clusters
+						for _, client := range clients {
+							// Repeat multiple times
+							for i := 0; i < 20; i++ {
+								Expect(t.execCmdOnRequestPod(&client, command)).NotTo(ContainSubstring("pod ip"), reportNonConformant(""))
+							}
 						}
 					}
 				})

--- a/conformance/endpoint_slice.go
+++ b/conformance/endpoint_slice.go
@@ -38,47 +38,54 @@ var _ = Describe("", Label(OptionalLabel, EndpointSliceLabel), func() {
 		"required MCS labels. Unexporting should delete the EndpointSlice.",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#using-endpointslice-objects-to-track-endpoints",
 		func() {
-			endpointSlices := make([]*discoveryv1.EndpointSlice, len(clients))
+			endpointSliceNames := make([][]string, len(clients))
 
 			for i, client := range clients {
-				eps := t.awaitMCSEndpointSlice(&client, discoveryv1.AddressTypeIPv4, nil, reportNonConformant(fmt.Sprintf(
-					"an MCS EndpointSlice was not found on cluster %q. An MCS EndpointSlice is identified by the presence "+
-						"of the required MCS labels (%q and %q). "+
-						"If the MCS implementation does not use MCS EndpointSlices, you can specify a Ginkgo label filter using "+
-						"the %q label where appropriate to skip this test.",
-					client.name, v1alpha1.LabelServiceName, v1alpha1.LabelSourceCluster, EndpointSliceLabel)))
+				for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
+					eps := t.awaitMCSEndpointSlice(&client, addressTypeOf(ipFamily), nil, reportNonConformant(fmt.Sprintf(
+						"an MCS EndpointSlice was not found on cluster %q. An MCS EndpointSlice is identified by the presence "+
+							"of the required MCS labels (%q and %q). "+
+							"If the MCS implementation does not use MCS EndpointSlices, you can specify a Ginkgo label filter using "+
+							"the %q label where appropriate to skip this test.",
+						client.name, v1alpha1.LabelServiceName, v1alpha1.LabelSourceCluster, EndpointSliceLabel)))
 
-				endpointSlices[i] = eps
+					endpointSliceNames[i] = append(endpointSliceNames[i], eps.Name)
 
-				Expect(eps.Labels).To(HaveKeyWithValue(v1alpha1.LabelServiceName, t.helloService.Name),
-					reportNonConformant(fmt.Sprintf("the MCS EndpointSlice %q does not contain the %q label referencing the service name",
-						eps.Name, v1alpha1.LabelServiceName)))
+					Expect(eps.Labels).To(HaveKeyWithValue(v1alpha1.LabelServiceName, t.helloService.Name),
+						reportNonConformant(fmt.Sprintf("the MCS EndpointSlice %q does not contain the %q label referencing the service name",
+							eps.Name, v1alpha1.LabelServiceName)))
 
-				Expect(eps.Labels).To(HaveKey(discoveryv1.LabelManagedBy),
-					reportNonConformant(fmt.Sprintf("the MCS EndpointSlice %q does not contain the %q label",
-						eps.Name, discoveryv1.LabelManagedBy)))
+					Expect(eps.Labels).To(HaveKey(discoveryv1.LabelManagedBy),
+						reportNonConformant(fmt.Sprintf("the MCS EndpointSlice %q does not contain the %q label",
+							eps.Name, discoveryv1.LabelManagedBy)))
 
-				if !skipVerifyEndpointSliceManagedBy {
-					Expect(eps.Labels[discoveryv1.LabelManagedBy]).ToNot(Equal(K8sEndpointSliceManagedByName),
-						reportNonConformant(fmt.Sprintf("the MCS EndpointSlice's %q label must not reference %q",
-							discoveryv1.LabelManagedBy, K8sEndpointSliceManagedByName)))
+					if !skipVerifyEndpointSliceManagedBy {
+						Expect(eps.Labels[discoveryv1.LabelManagedBy]).ToNot(Equal(K8sEndpointSliceManagedByName),
+							reportNonConformant(fmt.Sprintf("the MCS EndpointSlice's %q label must not reference %q",
+								discoveryv1.LabelManagedBy, K8sEndpointSliceManagedByName)))
+					}
 				}
 			}
 
 			t.deleteServiceExport(&clients[0])
 
 			for i, client := range clients {
-				Eventually(func() bool {
-					_, err := client.k8s.DiscoveryV1().EndpointSlices(t.namespace).Get(ctx, endpointSlices[i].Name, metav1.GetOptions{})
-					return apierrors.IsNotFound(err)
-				}, 20*time.Second, 100*time.Millisecond).Should(BeTrue(),
-					reportNonConformant(fmt.Sprintf("the EndpointSlice was not deleted on unexport from cluster %d", i+1)))
+				for _, name := range endpointSliceNames[i] {
+					Eventually(func() bool {
+						_, err := client.k8s.DiscoveryV1().EndpointSlices(t.namespace).Get(ctx, name, metav1.GetOptions{})
+						return apierrors.IsNotFound(err)
+					}, 20*time.Second, 100*time.Millisecond).Should(BeTrue(),
+						reportNonConformant(fmt.Sprintf("the EndpointSlice %q was not deleted on unexport from cluster %q",
+							name, client.name)))
+				}
 			}
 		})
 })
 
 func (t *testDriver) awaitMCSEndpointSlice(c *clusterClients, addressType discoveryv1.AddressType,
 	verify func(Gomega, *discoveryv1.EndpointSlice), desc ...any) *discoveryv1.EndpointSlice {
+	By(fmt.Sprintf("Retrieving %s MCS EndpointSlice for the service on cluster %q", addressType, c.name))
+
 	var endpointSlice *discoveryv1.EndpointSlice
 
 	hasLabel := func(eps *discoveryv1.EndpointSlice, label string) bool {

--- a/conformance/headless_service_dns.go
+++ b/conformance/headless_service_dns.go
@@ -49,19 +49,22 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 		"ready endpoint addresses of all the backing pods", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
-		command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)}
-
-		endpoints := t.awaitK8sEndpoints(&clients[0], discovery.AddressTypeIPv4)
-
-		var addresses []string
-		for _, ep := range endpoints {
-			addresses = append(addresses, ep.address)
-		}
-
 		for _, client := range clients {
-			By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
+			for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
+				command := []string{"sh", "-c", fmt.Sprintf("nslookup -type=%s %s.%s.svc.%s.", dnsRecordTypeOf(ipFamily),
+					t.helloService.Name, t.namespace, dnsDomain)}
 
-			t.awaitCmdOutputMatches(&client, command, HaveAddresses(addresses), 1, reportNonConformant(""))
+				endpoints := t.awaitK8sEndpoints(&clients[0], addressTypeOf(ipFamily))
+
+				var addresses []string
+				for _, ep := range endpoints {
+					addresses = append(addresses, ep.address)
+				}
+
+				By(fmt.Sprintf("Executing %s command %q on cluster %q", ipFamily, strings.Join(command, " "), client.name))
+
+				t.awaitCmdOutputMatches(&client, command, HaveAddresses(addresses), 1, reportNonConformant(""))
+			}
 		}
 	})
 
@@ -80,35 +83,39 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
 			for _, client := range clients {
-				eps := t.awaitMCSEndpointSlice(&client, discovery.AddressTypeIPv4, func(g Gomega, eps *discovery.EndpointSlice) {
-					g.Expect(eps.Endpoints).To(HaveLen(replicas),
-						"the MCS EndpointSlice %q does not contain the expected number of endpoints %d",
-						eps.Name, replicas)
+				for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
+					eps := t.awaitMCSEndpointSlice(&client, addressTypeOf(ipFamily), func(g Gomega, eps *discovery.EndpointSlice) {
+						g.Expect(eps.Endpoints).To(HaveLen(replicas),
+							"the MCS EndpointSlice %q does not contain the expected number of endpoints %d",
+							eps.Name, replicas)
+
+						for i := range eps.Endpoints {
+							ep := eps.Endpoints[i]
+
+							g.Expect(ptr.Deref(ep.Conditions.Ready, true)).To(BeTrue(),
+								"the endpoint address %s in the MCS EndpointSlice %q is not ready",
+								strings.Join(ep.Addresses, ","), eps.Name)
+
+							g.Expect(ptr.Deref(ep.Hostname, "")).ToNot(BeEmpty(),
+								"the hostname field for endpoint address %s in the MCS EndpointSlice %q is not set",
+								strings.Join(ep.Addresses, ","), eps.Name)
+						}
+					}, "an MCS EndpointSlice was not found on cluster %q", client.name)
+
+					clusterID := eps.Labels[v1alpha1.LabelSourceCluster]
 
 					for i := range eps.Endpoints {
-						ep := eps.Endpoints[i]
+						ep := &eps.Endpoints[i]
 
-						g.Expect(ptr.Deref(ep.Conditions.Ready, true)).To(BeTrue(),
-							"the endpoint address %s in the MCS EndpointSlice %q is not ready",
-							strings.Join(ep.Addresses, ","), eps.Name)
+						// Add trailing dot to prevent search domain from being appended
+						command := []string{"sh", "-c", fmt.Sprintf("nslookup -type=%s %s.%s.%s.%s.svc.%s.",
+							dnsRecordTypeOf(ipFamily), ptr.Deref(ep.Hostname, ""), clusterID, t.helloService.Name,
+							t.namespace, dnsDomain)}
 
-						g.Expect(ptr.Deref(ep.Hostname, "")).ToNot(BeEmpty(),
-							"the hostname field for endpoint address %s in the MCS EndpointSlice %q is not set",
-							strings.Join(ep.Addresses, ","), eps.Name)
+						By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
+
+						t.awaitCmdOutputMatches(&client, command, HaveAddresses(ep.Addresses), 1, reportNonConformant(""))
 					}
-				}, "an MCS EndpointSlice was not found on cluster %q", client.name)
-
-				clusterID := eps.Labels[v1alpha1.LabelSourceCluster]
-
-				for i := range eps.Endpoints {
-					ep := &eps.Endpoints[i]
-
-					command := []string{"sh", "-c", fmt.Sprintf("nslookup %s.%s.%s.%s.svc.%s",
-						ptr.Deref(ep.Hostname, ""), clusterID, t.helloService.Name, t.namespace, dnsDomain)}
-
-					By(fmt.Sprintf("Executing command %q on cluster %q", strings.Join(command, " "), client.name))
-
-					t.awaitCmdOutputMatches(&client, command, HaveAddresses(ep.Addresses), 1, reportNonConformant(""))
 				}
 			}
 		})
@@ -118,17 +125,20 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 		"records", func() {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
-		endpoints := t.awaitK8sEndpoints(&clients[0], discovery.AddressTypeIPv4)
+		// Collect endpoints for all IP families in the service (for dual-stack support)
+		var allEndpoints []endpointInfo
+		for _, ipFamily := range t.helloService.Spec.IPFamilies {
+			endpoints := t.awaitK8sEndpoints(&clients[0], addressTypeOf(ipFamily))
+			allEndpoints = append(allEndpoints, endpoints...)
+		}
 
 		domainName := fmt.Sprintf("%s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)
 
 		for _, client := range clients {
-			srvRecs := t.expectSRVRecords(&client, domainName)
+			srvRecs := t.expectSRVRecords(&client, domainName, len(allEndpoints))
 
-			Expect(srvRecs).To(HaveLen(len(endpoints)), reportNonConformant(
-				fmt.Sprintf("Expected %d SRV records. Received %d: %v", len(endpoints), len(srvRecs), srvRecs)))
-
-			for _, ep := range endpoints {
+			// Verify each endpoint has a corresponding SRV record
+			for _, ep := range allEndpoints {
 				index := slices.IndexFunc(srvRecs, func(r srvRecord) bool {
 					return strings.HasPrefix(r.domainName, ep.hostName)
 				})
@@ -153,7 +163,7 @@ func (e endpointInfo) String() string {
 }
 
 func (t *testDriver) awaitK8sEndpoints(c *clusterClients, addressType discovery.AddressType) []endpointInfo {
-	By(fmt.Sprintf("Retrieving K8s endpoint addresses for the service on cluster %q", c.name))
+	By(fmt.Sprintf("Retrieving %s K8s endpoint addresses for the service on cluster %q", addressType, c.name))
 
 	var endpoints []endpointInfo
 

--- a/conformance/k8s_objects.go
+++ b/conformance/k8s_objects.go
@@ -53,6 +53,7 @@ func newHelloService() *corev1.Service {
 			SessionAffinityConfig: &corev1.SessionAffinityConfig{
 				ClientIP: &corev1.ClientIPConfig{TimeoutSeconds: ptr.To(int32(10))},
 			},
+			IPFamilyPolicy: ptr.To(corev1.IPFamilyPolicyPreferDualStack),
 		},
 	}
 }
@@ -67,18 +68,64 @@ func newHelloServiceExport() *v1alpha1.ServiceExport {
 	}
 }
 
+// socatListenerScript generates a shell script that detects the pod's IP family configuration
+// and starts the appropriate socat listener (IPv4, IPv6, or dual-stack).
+func socatListenerScript(protocol string) string {
+	return `# Detect IP families available on the pod from podIPs
+# The downward API provides podIPs as a plain string (single IP or space/comma-separated list)
+has_ipv4=false
+has_ipv6=false
+
+# Check for IPv4 pattern (dotted decimal notation)
+if echo "$MY_POD_IPS" | grep -qE '([^0-9]|^)[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}([^0-9]|$)'; then has_ipv4=true; fi
+
+# Check for IPv6 pattern (hex digits with at least two colons)
+if echo "$MY_POD_IPS" | grep -qE '[0-9a-fA-F]*:[0-9a-fA-F]*:[0-9a-fA-F:]*'; then has_ipv6=true; fi
+
+# Debug: log what we detected
+echo "DEBUG: MY_POD_IPS=$MY_POD_IPS" >&2
+echo "DEBUG: has_ipv4=$has_ipv4, has_ipv6=$has_ipv6" >&2
+
+# Extract first IP address (may be space or comma separated)
+first_ip=$(echo "$MY_POD_IPS" | tr ',' ' ' | awk '{print $1}')
+echo "DEBUG: first_ip=$first_ip" >&2
+
+# Choose socat listener based on available IP families
+# Export first_ip so it's available to SYSTEM subprocesses
+export first_ip
+
+if $has_ipv6 && $has_ipv4; then
+	# Dual-stack: use IPv6 socket that accepts both
+	echo "DEBUG: Starting dual-stack listener" >&2
+	socat -v -v ` + protocol + `6-LISTEN:42,crlf,reuseaddr,fork,ipv6only=0 SYSTEM:'echo "pod ip $first_ip"'
+elif $has_ipv6; then
+	# IPv6 only
+	echo "DEBUG: Starting IPv6-only listener" >&2
+	socat -v -v ` + protocol + `6-LISTEN:42,crlf,reuseaddr,fork SYSTEM:'echo "pod ip $first_ip"'
+else
+	# IPv4 only
+	echo "DEBUG: Starting IPv4-only listener" >&2
+	socat -v -v ` + protocol + `-LISTEN:42,crlf,reuseaddr,fork SYSTEM:'echo "pod ip $first_ip"'
+fi`
+}
+
 func podContainers() []corev1.Container {
 	return []corev1.Container{
 		{
 			Name:  "hello-tcp",
 			Image: "alpine/socat:1.7.4.4",
-			Args:  []string{"-v", "-v", "TCP-LISTEN:42,crlf,reuseaddr,fork", "SYSTEM:echo pod ip $(MY_POD_IP)"},
+			// Detect if pod has IPv4, IPv6, or both and use appropriate socat listener
+			// - IPv4 only: use TCP-LISTEN
+			// - IPv6 only: use TCP6-LISTEN (no ipv6only flag needed)
+			// - Dual-stack: use TCP6-LISTEN with ipv6only=0 to handle both
+			Command: []string{"/bin/sh"},
+			Args:    []string{"-c", socatListenerScript("TCP")},
 			Env: []corev1.EnvVar{
 				{
-					Name: "MY_POD_IP",
+					Name: "MY_POD_IPS",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "status.podIP",
+							FieldPath: "status.podIPs",
 						},
 					},
 				},
@@ -87,13 +134,18 @@ func podContainers() []corev1.Container {
 		{
 			Name:  "hello-udp",
 			Image: "alpine/socat:1.7.4.4",
-			Args:  []string{"-v", "-v", "UDP-LISTEN:42,crlf,reuseaddr,fork", "SYSTEM:echo pod ip $(MY_POD_IP)"},
+			// Detect if pod has IPv4, IPv6, or both and use appropriate socat listener
+			// - IPv4 only: use UDP-LISTEN
+			// - IPv6 only: use UDP6-LISTEN (no ipv6only flag needed)
+			// - Dual-stack: use UDP6-LISTEN with ipv6only=0 to handle both
+			Command: []string{"/bin/sh"},
+			Args:    []string{"-c", socatListenerScript("UDP")},
 			Env: []corev1.EnvVar{
 				{
-					Name: "MY_POD_IP",
+					Name: "MY_POD_IPS",
 					ValueFrom: &corev1.EnvVarSource{
 						FieldRef: &corev1.ObjectFieldSelector{
-							FieldPath: "status.podIP",
+							FieldPath: "status.podIPs",
 						},
 					},
 				},
@@ -164,7 +216,7 @@ func newRequestPod() *corev1.Pod {
 			Containers: []corev1.Container{
 				{
 					Name:  "request",
-					Image: "busybox",
+					Image: "nicolaka/netshoot:v0.15",
 					Args:  []string{"/bin/sh", "-ec", "while :; do echo '.'; sleep 5 ; done"},
 				},
 			},

--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -202,7 +202,7 @@ func testClusterIPServiceImport() {
 		)
 	})
 
-	SpecifyWithSpecRef("An IP should be allocated for a ClusterSetIP ServiceImport",
+	SpecifyWithSpecRef("An IP should be allocated for a ClusterSetIP ServiceImport for each IP family",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#clustersetip",
 		Label(RequiredLabel), func() {
 			serviceImport := t.awaitServiceImport(&clients[0], t.helloService.Name, false,
@@ -210,8 +210,19 @@ func testClusterIPServiceImport() {
 					g.Expect(serviceImport.Spec.IPs).ToNot(BeEmpty(), reportNonConformant(""))
 				})
 
-			Expect(net.ParseIP(serviceImport.Spec.IPs[0])).ToNot(BeNil(),
-				reportNonConformant(fmt.Sprintf("The value %q is not a valid IP", serviceImport.Spec.IPs[0])))
+			Expect(serviceImport.Spec.IPs).To(HaveLen(len(serviceImport.Spec.IPFamilies)), reportNonConformant(
+				"The ServiceImport IPs field must have the same number of IPs as ServiceImport IPFamilies"))
+
+			// Verify the IPs are valid and are in the same order as IPFamilies.
+			for i := range serviceImport.Spec.IPs {
+				Expect(net.ParseIP(serviceImport.Spec.IPs[i])).ToNot(BeNil(),
+					reportNonConformant(fmt.Sprintf("The value %q is not a valid IP", serviceImport.Spec.IPs[i])))
+
+				Expect(ipFamilyOf(serviceImport.Spec.IPs[i])).To(Equal(serviceImport.Spec.IPFamilies[i]),
+					reportNonConformant(fmt.Sprintf(
+						"The IP family of ServiceImport.Spec.IPs[%d] (%q) must match ServiceImport.Spec.IPFamilies[%d] (%q)",
+						i, serviceImport.Spec.IPs[i], i, serviceImport.Spec.IPFamilies[i])))
+			}
 		})
 
 	SpecifyWithSpecRef("The ports for a ClusterSetIP ServiceImport should match those of the exported service",
@@ -316,6 +327,7 @@ func testExternalNameService() {
 	BeforeEach(func() {
 		t.helloService.Spec.Type = corev1.ServiceTypeExternalName
 		t.helloService.Spec.ExternalName = "example.com"
+		t.helloService.Spec.IPFamilyPolicy = nil
 	})
 
 	SpecifyWithSpecRef("Exporting an ExternalName service should set ServiceExport Valid condition to False",


### PR DESCRIPTION
Updates the conformance test suite to properly handle IPv4-only, IPv6-only, and dual-stack configurations. The tests adapt to the underlying IP family configuration of the K8s clusters.

Client-side changes:
- Iterate over each `ServiceImport` IP and service `IPFamily` to support multiple IP families in ClusterIP and headless DNS tests
- Use the IP family to determine the appropriate DNS record type (A for IPv4, AAAA for IPv6) in `nslookup` commands
- Add trailing dots to `nslookup` FQDNs to prevent DNS search domain issues
- Dynamically select the correct address type (IPv4/IPv6) when retrieving and validating endpoint slices
- Switch request pod image from **busybox** to **nicolaka/netshoot** for better IPv6 support and networking tools (`nc` with -4/-6 flags, `nslookup` with AAAA record support)
- For IPv6 connectivity tests, use explicit DNS resolution (`nslookup`) and pass the resolved IP to `nc`, as `nc -6` with hostname hangs in IPv6-only environments
- Validate that `ServiceImport` IPs match the service's `IPFamilies` in count and family type

Server-side changes:
- Create `socatListenerScript()` that auto-detects pod IP configuration using `MY_POD_IPS` environment variable
- Configure `socat` listeners appropriately:
  * IPv4-only: TCP-LISTEN
  * IPv6-only: TCP6-LISTEN
  * Dual-stack: TCP6-LISTEN with ipv6only=0

SRV record test improvements:
- Wait for expected number of SRV records across all IP families to be present before validating
- Collect endpoints for all IP families in dual-stack headless service tests
- Strip trailing periods from parsed SRV record domain names

Helper functions added:
- `dnsRecordTypeOf()`: derive DNS record type (A/AAAA) from IP family
- `addressTypeOf()`: derive `EndpointSlice` address type from IP family
- `ipFamilyOf()`: determine IP family from IP address string
- `ncCommand()`: generate `nc` command with IP family-specific handling
- `socatListenerScript()`: generate dual-stack aware socat listener script