### PR TITLE
conformance: generate report in yaml format

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,4 +49,5 @@ Session.vim
 .vscode
 /www/test_out
 report.html
+report.yaml
 .*.timestamp

--- a/conformance/report.go
+++ b/conformance/report.go
@@ -31,6 +31,7 @@ import (
 	"github.com/onsi/ginkgo/v2/types"
 	. "github.com/onsi/gomega"
 	"github.com/onsi/gomega/matchers"
+	"gopkg.in/yaml.v3"
 )
 
 const (
@@ -60,6 +61,7 @@ type testInfo struct {
 	Desc       string
 	Ref        string
 	Labels     []string
+	Passed     bool
 	Failed     bool
 	Skipped    bool
 	Conformant bool
@@ -166,7 +168,7 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 			}
 
 			info := testInfo{
-				Desc:       specReport.FullText(),
+				Desc:       strings.TrimSpace(specReport.FullText()),
 				Conformant: true,
 			}
 
@@ -202,6 +204,8 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 				info.Message = parseFailureMessage(specReport.FailureMessage())
 			}
 
+			info.Passed = !info.Failed && !info.Skipped && info.Conformant
+
 			if info.Message != "" {
 				info.Message = " - " + info.Message
 			}
@@ -223,14 +227,29 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 		}
 	}
 
+	totalTests := 0
+	passedTests := 0
+	for _, g := range testGroups {
+		for _, t := range g.Tests {
+			totalTests++
+			if t.Passed {
+				passedTests++
+			}
+		}
+	}
+
 	data := struct {
 		Groups       []testGrouping
 		SuiteFailure string
 		DNSDomain    string
+		Passed       int
+		Total        int
 	}{
 		Groups:       testGroups,
 		SuiteFailure: suiteFailure,
 		DNSDomain:    dnsDomain,
+		Passed:       passedTests,
+		Total:        totalTests,
 	}
 
 	out, err := os.Create("report.html")
@@ -240,6 +259,12 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 	Expect(err).To(Succeed())
 
 	err = tmpl.Execute(out, data)
+	Expect(err).To(Succeed())
+
+	yamlOut, err := os.Create("report.yaml")
+	Expect(err).To(Succeed())
+
+	err = yaml.NewEncoder(yamlOut).Encode(data)
 	Expect(err).To(Succeed())
 })
 

--- a/conformance/report_template.gohtml
+++ b/conformance/report_template.gohtml
@@ -14,6 +14,7 @@
 </head>
 <body>
 <h2>MCS Conformance Report</h2>
+<p><strong>{{.Passed}}</strong> of <strong>{{.Total}}</strong> tests passed</p>
 
 {{if and .DNSDomain (ne .DNSDomain "clusterset.local")}}
     <p>DNS domain suffix: <strong>{{.DNSDomain}}</strong></p>


### PR DESCRIPTION
## Summary 
Fixes #144
Generate report in yaml format from the conformance reporting tool along with the html report. 

The yaml report also includes `total` (total number of tests in the suite) and `passed` (number of tests that passed) fields for a quick summary of conformance results.

Below is how the yaml file looks
```yaml
groups:
    - name: Required
      tests:
...
        - desc: Connectivity to a service that is not exported should be inaccessible
          ref: https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#exporting-services
          labels: []
          passed: true
          failed: false
          skipped: false
          conformant: true
          message: ""
...
suitefailure: ""
dnsdomain: clusterset.local
passed: 2
total: 27
```