### PR TITLE
Conformance: Accept implementation metadata via cli flags

### DIFF
--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -58,6 +58,10 @@ var (
 	loadingRules                     *clientcmd.ClientConfigLoadingRules
 	skipVerifyEndpointSliceManagedBy bool
 	dnsDomain                        string
+	organization                     string
+	project                          string
+	version                          string
+	url                              string
 	ctx                              = context.TODO()
 )
 
@@ -80,6 +84,10 @@ func init() {
 			discoveryv1.LabelManagedBy, K8sEndpointSliceManagedByName))
 	flag.StringVar(&dnsDomain, "dns-domain", "clusterset.local", "The DNS domain suffix used for multi-cluster services. "+
 		"The default is \"clusterset.local\" as specified by the MCS spec, but some implementations may use a custom domain.")
+	flag.StringVar(&organization, "organization", "", "Name of the organization responsible for the MCS implementation")
+	flag.StringVar(&project, "project", "", "Name of the MCS implementation project being tested")
+	flag.StringVar(&version, "version", "", "Version of the MCS implementation being tested")
+	flag.StringVar(&url, "url", "", "A URL pointing to the MCS implementation project or documentation")
 }
 
 var _ = BeforeSuite(func() {

--- a/conformance/report.go
+++ b/conformance/report.go
@@ -73,6 +73,13 @@ type testGrouping struct {
 	Tests []testInfo
 }
 
+type implementationInfo struct {
+	Organization string
+	Project      string
+	Version      string
+	URL          string
+}
+
 var (
 	errorRegEx *regexp.Regexp
 	// currentSpecNonConformanceMsg holds the last non-conformance message emitted by the current spec. Using
@@ -239,17 +246,24 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 	}
 
 	data := struct {
-		Groups       []testGrouping
-		SuiteFailure string
-		DNSDomain    string
-		Passed       int
-		Total        int
+		Groups         []testGrouping
+		SuiteFailure   string
+		DNSDomain      string
+		Passed         int
+		Total          int
+		Implementation implementationInfo
 	}{
 		Groups:       testGroups,
 		SuiteFailure: suiteFailure,
 		DNSDomain:    dnsDomain,
 		Passed:       passedTests,
 		Total:        totalTests,
+		Implementation: implementationInfo{
+			Organization: organization,
+			Project:      project,
+			Version:      version,
+			URL:          url,
+		},
 	}
 
 	out, err := os.Create("report.html")


### PR DESCRIPTION
Fixes: #147

### Summary
- Add optional CLI flags (`--organization`, `--project`, `--version`, `--url`) to capture details about the MCS implementation being tested
- Include the implementation metadata in the YAML report under a nested implementation key

Example:
```yaml
implementation:
    organization: test org
    project: test project
    version: v0.1.0
    url: https://example.com
```
                                                                                                                                                                                                                     
### Test plan
- Ran the conformance test with the new flags and verified that the YAML report contains the implementation section
```
  go -C conformance run github.com/onsi/ginkgo/v2/ginkgo . -- \
    --kubeconfig=$HOME/.kube/config --contexts=kind-c1,kind-c2 \
    --organization="test org" --project="test project" \
    --version="v0.1.0" --url="https://example.com"
```
  - Running without the new flags generates empty implementation fields.
```yaml
implementation:
    organization: ""
    project: ""
    version: ""
    url: ""
```
