### PR TITLE
Conformance: Track required tests in report.yaml

### DIFF
--- a/conformance/report.go
+++ b/conformance/report.go
@@ -236,8 +236,19 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 
 	totalTests := 0
 	passedTests := 0
+	requiredTotal := 0
+	requiredPassed := 0
 	for _, g := range testGroups {
 		for _, t := range g.Tests {
+			// Track required tests. Implementation is conformant if all required tests pass.
+			if g.Name == RequiredLabel {
+				requiredTotal++
+				if t.Passed {
+					requiredPassed++
+				}
+			}
+
+			// Overall totals include both required and optional tests.
 			totalTests++
 			if t.Passed {
 				passedTests++
@@ -251,13 +262,17 @@ var _ = ReportAfterSuite("MCS conformance report", func(report Report) {
 		DNSDomain      string
 		Passed         int
 		Total          int
+		RequiredPassed int
+		RequiredTotal  int
 		Implementation implementationInfo
 	}{
-		Groups:       testGroups,
-		SuiteFailure: suiteFailure,
-		DNSDomain:    dnsDomain,
-		Passed:       passedTests,
-		Total:        totalTests,
+		Groups:         testGroups,
+		SuiteFailure:   suiteFailure,
+		DNSDomain:      dnsDomain,
+		Passed:         passedTests,
+		Total:          totalTests,
+		RequiredPassed: requiredPassed,
+		RequiredTotal:  requiredTotal,
 		Implementation: implementationInfo{
 			Organization: organization,
 			Project:      project,


### PR DESCRIPTION
### Summary
Include the total no. of required tests and the no. of required tests an implementation passed. The idea came from https://github.com/kubernetes-sigs/sig-multicluster-site/pull/54 where the conformance matrix need to show if an implementation passed all the required tests which determines if an implementation is conformant or not. 

### Test Plan
1. Running the conformance tool showed that report.yaml included two new fields `requiredpassed` and `requiredtotal`
```yaml
dnsdomain: clusterset.local
passed: 2
total: 27
requiredpassed: 1
requiredtotal: 14
```