### PR TITLE
Propagate the Ginkgo context

### DIFF
--- a/conformance/clusterip_service_dns.go
+++ b/conformance/clusterip_service_dns.go
@@ -22,6 +22,7 @@ import (
 	"regexp"
 	"strconv"
 	"strings"
+	"time"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -33,11 +34,11 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 	t := newTestDriver()
 
 	Specify("A DNS lookup of the <service>.<ns>.svc."+dnsDomain+" domain for a ClusterIP service should resolve to the "+
-		"clusterset IP", func() {
+		"clusterset IP", func(ctx context.Context) {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
 		for _, client := range clients {
-			serviceImport := t.awaitServiceImport(&client, t.helloService.Name, false,
+			serviceImport := t.awaitServiceImport(ctx, &client, t.helloService.Name, false,
 				func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 					g.Expect(serviceImport.Spec.IPs).ToNot(BeEmpty(), "ServiceImport on cluster %q does not contain an IP", client.name)
 				})
@@ -77,21 +78,21 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, ClusterIPLabel), func() {
 	})
 
 	Specify("DNS lookups of the <service>.<ns>.svc.cluster.local domain for a ClusterIP service should only resolve "+
-		"local services", func() {
+		"local services", func(ctx context.Context) {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
 		By(fmt.Sprintf("Retrieving local Service on cluster %q", clients[0].name))
 
 		var resolvedIP string
 
-		Eventually(func() string {
-			svc, err := clients[0].k8s.CoreV1().Services(t.namespace).Get(context.TODO(), t.helloService.Name, metav1.GetOptions{})
+		Eventually(func(ctx context.Context) string {
+			svc, err := clients[0].k8s.CoreV1().Services(t.namespace).Get(ctx, t.helloService.Name, metav1.GetOptions{})
 			Expect(err).ToNot(HaveOccurred(), "Error retrieving the local Service")
 
 			resolvedIP = svc.Spec.ClusterIP
 
 			return resolvedIP
-		}, 20, 1).ShouldNot(BeEmpty(), "The service was not assigned a cluster IP")
+		}).WithContext(ctx).Within(20*time.Second).ProbeEvery(1*time.Second).ShouldNot(BeEmpty(), "The service was not assigned a cluster IP")
 
 		By(fmt.Sprintf("Found local Service cluster IP %q", resolvedIP))
 

--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -62,7 +62,6 @@ var (
 	project                          string
 	version                          string
 	url                              string
-	ctx                              = context.TODO()
 )
 
 // TestConformance runs the conformance test.
@@ -90,11 +89,11 @@ func init() {
 	flag.StringVar(&url, "url", "", "A URL pointing to the MCS implementation project or documentation")
 }
 
-var _ = BeforeSuite(func() {
-	Expect(setupClients()).To(Succeed(), "Test suite set up failed")
+var _ = BeforeSuite(func(ctx context.Context) {
+	Expect(setupClients(ctx)).To(Succeed(), "Test suite set up failed")
 })
 
-func setupClients() error {
+func setupClients(ctx context.Context) error {
 	splitContexts := strings.Split(contexts, ",")
 	clients = make([]clusterClients, len(splitContexts))
 	accumulatedErrors := []error{}
@@ -136,11 +135,11 @@ func setupClients() error {
 				return fmt.Errorf("error setting up an MCS API client on context %s: %w", name, err)
 			}
 
-			if _, err := mcsClient.MulticlusterV1beta1().ServiceExports("").List(context.TODO(), metav1.ListOptions{}); err != nil {
+			if _, err := mcsClient.MulticlusterV1beta1().ServiceExports("").List(ctx, metav1.ListOptions{}); err != nil {
 				return fmt.Errorf("error listing ServiceExports on context %s: %w. Is the MCS API installed?", name, err)
 			}
 
-			if _, err := mcsClient.MulticlusterV1beta1().ServiceImports("").List(context.TODO(), metav1.ListOptions{}); err != nil {
+			if _, err := mcsClient.MulticlusterV1beta1().ServiceImports("").List(ctx, metav1.ListOptions{}); err != nil {
 				return fmt.Errorf("error listing ServiceImports on context %s: %w. Is the MCS API installed?", name, err)
 			}
 
@@ -176,7 +175,7 @@ func newTestDriver() *testDriver {
 		t.autoExportService = true
 	})
 
-	JustBeforeEach(func() {
+	JustBeforeEach(func(ctx context.Context) {
 		Expect(clients).ToNot(BeEmpty())
 
 		// Set up the shared namespace
@@ -188,7 +187,7 @@ func newTestDriver() *testDriver {
 		}
 
 		// Set up the remote service (the first cluster is considered to be the remote)
-		t.helloService = t.deployHelloService(&clients[0], t.helloService)
+		t.helloService = t.deployHelloService(ctx, &clients[0], t.helloService)
 
 		// Start the request pod on all clusters
 		for _, client := range clients {
@@ -196,11 +195,11 @@ func newTestDriver() *testDriver {
 		}
 
 		if t.autoExportService {
-			t.createServiceExport(&clients[0], t.helloServiceExport)
+			t.createServiceExport(ctx, &clients[0], t.helloServiceExport)
 		}
 	})
 
-	AfterEach(func() {
+	AfterEach(func(ctx context.Context) {
 		// Clean up the shared namespace
 		for _, client := range clients {
 			err := client.k8s.CoreV1().Namespaces().Delete(ctx, t.namespace, metav1.DeleteOptions{})
@@ -213,7 +212,7 @@ func newTestDriver() *testDriver {
 	return t
 }
 
-func (t *testDriver) createServiceExport(c *clusterClients, serviceExport *v1beta1.ServiceExport) {
+func (t *testDriver) createServiceExport(ctx context.Context, c *clusterClients, serviceExport *v1beta1.ServiceExport) {
 	_, err := c.mcs.MulticlusterV1beta1().ServiceExports(t.namespace).Create(
 		ctx, serviceExport, metav1.CreateOptions{})
 	Expect(err).ToNot(HaveOccurred())
@@ -221,14 +220,14 @@ func (t *testDriver) createServiceExport(c *clusterClients, serviceExport *v1bet
 	By(fmt.Sprintf("Service \"%s/%s\" exported on cluster %q", t.namespace, helloServiceName, c.name))
 }
 
-func (t *testDriver) deleteServiceExport(c *clusterClients) {
+func (t *testDriver) deleteServiceExport(ctx context.Context, c *clusterClients) {
 	Expect(c.mcs.MulticlusterV1beta1().ServiceExports(t.namespace).Delete(ctx, helloServiceName,
 		metav1.DeleteOptions{})).ToNot(HaveOccurred())
 
 	By(fmt.Sprintf("Service \"%s/%s\" unexported on cluster %q", t.namespace, helloServiceName, c.name))
 }
 
-func (t *testDriver) deployHelloService(c *clusterClients, service *corev1.Service) *corev1.Service {
+func (t *testDriver) deployHelloService(ctx context.Context, c *clusterClients, service *corev1.Service) *corev1.Service {
 	if t.helloDeployment != nil {
 		_, err := c.k8s.AppsV1().Deployments(t.namespace).Create(ctx, t.helloDeployment, metav1.CreateOptions{})
 		Expect(err).ToNot(HaveOccurred())
@@ -243,7 +242,7 @@ func (t *testDriver) deployHelloService(c *clusterClients, service *corev1.Servi
 	return deployed
 }
 
-func (t *testDriver) getServiceImport(c *clusterClients, name string) *v1beta1.ServiceImport {
+func (t *testDriver) getServiceImport(ctx context.Context, c *clusterClients, name string) *v1beta1.ServiceImport {
 	si, err := c.mcs.MulticlusterV1beta1().ServiceImports(t.namespace).Get(ctx, name, metav1.GetOptions{})
 	if apierrors.IsNotFound(err) || errors.Is(err, context.DeadlineExceeded) ||
 		(err != nil && strings.Contains(err.Error(), "rate limiter")) {
@@ -255,14 +254,14 @@ func (t *testDriver) getServiceImport(c *clusterClients, name string) *v1beta1.S
 	return si
 }
 
-func (t *testDriver) awaitServiceImport(c *clusterClients, name string, reportNonConformanceOnMissing bool,
+func (t *testDriver) awaitServiceImport(ctx context.Context, c *clusterClients, name string, reportNonConformanceOnMissing bool,
 	verify func(Gomega, *v1beta1.ServiceImport)) *v1beta1.ServiceImport {
 	var serviceImport *v1beta1.ServiceImport
 
 	By(fmt.Sprintf("Retrieving ServiceImport for %q on cluster %q", name, c.name))
 
-	Eventually(func(g Gomega) {
-		si := t.getServiceImport(c, name)
+	Eventually(func(g Gomega, ctx context.Context) {
+		si := t.getServiceImport(ctx, c, name)
 
 		missingMsg := fmt.Sprintf("ServiceImport was not found on cluster %q", c.name)
 
@@ -281,13 +280,13 @@ func (t *testDriver) awaitServiceImport(c *clusterClients, name string, reportNo
 
 		// The final run succeeded so cancel any prior non-conformance reported.
 		cancelNonConformanceReport()
-	}).Within(20 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+	}).WithContext(ctx).Within(20 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 	return serviceImport
 }
 
-func (t *testDriver) awaitServiceImportIPFamilies(c *clusterClients) []corev1.IPFamily {
-	serviceImport := t.awaitServiceImport(c, t.helloService.Name, false,
+func (t *testDriver) awaitServiceImportIPFamilies(ctx context.Context, c *clusterClients) []corev1.IPFamily {
+	serviceImport := t.awaitServiceImport(ctx, c, t.helloService.Name, false,
 		func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 			g.Expect(serviceImport.Spec.IPFamilies).NotTo(BeEmpty(),
 				"ServiceImport on cluster %q does not contain an IP family", c.name)
@@ -296,7 +295,7 @@ func (t *testDriver) awaitServiceImportIPFamilies(c *clusterClients) []corev1.IP
 	return serviceImport.Spec.IPFamilies
 }
 
-func (t *testDriver) awaitNoServiceImport(c *clusterClients, name, nonConformanceMsg string) {
+func (t *testDriver) awaitNoServiceImport(ctx context.Context, c *clusterClients, name, nonConformanceMsg string) {
 	Eventually(func() bool {
 		_, err := c.mcs.MulticlusterV1beta1().ServiceImports(t.namespace).Get(ctx, name, metav1.GetOptions{})
 		if apierrors.IsNotFound(err) {
@@ -309,21 +308,21 @@ func (t *testDriver) awaitNoServiceImport(c *clusterClients, name, nonConformanc
 	}, 20*time.Second, 100*time.Millisecond).Should(BeTrue(), reportNonConformant(nonConformanceMsg))
 }
 
-func (t *testDriver) ensureServiceImport(c *clusterClients, name, nonConformanceMsg string) {
+func (t *testDriver) ensureServiceImport(ctx context.Context, c *clusterClients, name, nonConformanceMsg string) {
 	Consistently(func() error {
 		_, err := c.mcs.MulticlusterV1beta1().ServiceImports(t.namespace).Get(ctx, name, metav1.GetOptions{})
 		return err
 	}, 5*time.Second, 100*time.Millisecond).ShouldNot(HaveOccurred(), reportNonConformant(nonConformanceMsg))
 }
 
-func (t *testDriver) ensureNoServiceImport(c *clusterClients, name, nonConformanceMsg string) {
+func (t *testDriver) ensureNoServiceImport(ctx context.Context, c *clusterClients, name, nonConformanceMsg string) {
 	Consistently(func() bool {
 		_, err := c.mcs.MulticlusterV1beta1().ServiceImports(t.namespace).Get(ctx, name, metav1.GetOptions{})
 		return apierrors.IsNotFound(err)
 	}, 5*time.Second, 100*time.Millisecond).Should(BeTrue(), reportNonConformant(nonConformanceMsg))
 }
 
-func (t *testDriver) awaitServiceExportCondition(c *clusterClients, condType v1beta1.ServiceExportConditionType,
+func (t *testDriver) awaitServiceExportCondition(ctx context.Context, c *clusterClients, condType v1beta1.ServiceExportConditionType,
 	wantStatus metav1.ConditionStatus) {
 	Eventually(func() bool {
 		se, err := c.mcs.MulticlusterV1beta1().ServiceExports(t.namespace).Get(ctx, helloServiceName, metav1.GetOptions{})
@@ -374,13 +373,13 @@ func (t *testDriver) awaitCmdOutputMatches(c *clusterClients, command []string, 
 	}).Within(time.Duration(20*int64(nIter))*time.Second).ProbeEvery(time.Second).MustPassRepeatedly(nIter).Should(Succeed(), msg)
 }
 
-func (t *testDriver) awaitServicePodIP(c *clusterClients) string {
+func (t *testDriver) awaitServicePodIP(ctx context.Context, c *clusterClients) string {
 	By(fmt.Sprintf("Awaiting service deployment pod IP on cluster %q", c.name))
 
 	servicePodIP := ""
 
-	Eventually(func(g Gomega) {
-		pods, err := c.k8s.CoreV1().Pods(t.namespace).List(context.TODO(), metav1.ListOptions{
+	Eventually(func(g Gomega, ctx context.Context) {
+		pods, err := c.k8s.CoreV1().Pods(t.namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: metav1.FormatLabelSelector(newHelloDeployment().Spec.Selector),
 		})
 
@@ -389,16 +388,16 @@ func (t *testDriver) awaitServicePodIP(c *clusterClients) string {
 
 		servicePodIP = pods.Items[0].Status.PodIP
 		g.Expect(servicePodIP).NotTo(BeEmpty(), "Service deployment pod was not allocated an IP")
-	}).Within(20 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+	}).WithContext(ctx).Within(20 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 	By(fmt.Sprintf("Retrieved service deployment pod IP %q", servicePodIP))
 
 	return servicePodIP
 }
 
-func (t *testDriver) execPortConnectivityCommand(port int, matchStr string, nIter int) {
+func (t *testDriver) execPortConnectivityCommand(ctx context.Context, port int, matchStr string, nIter int) {
 	for _, client := range clients {
-		for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
+		for _, ipFamily := range t.awaitServiceImportIPFamilies(ctx, &client) {
 			serviceFQDN := fmt.Sprintf("%s.%s.svc.%s", t.helloService.Name, t.namespace, dnsDomain)
 			command := []string{"sh", "-c", ncCommand(ipFamily, serviceFQDN, port)}
 
@@ -426,22 +425,22 @@ func newTwoClusterTestDriver(t *testDriver) *twoClusterTestDriver {
 		t.autoExportService = false
 	})
 
-	JustBeforeEach(func() {
-		t.createServiceExport(&clients[0], t.helloServiceExport)
+	JustBeforeEach(func(ctx context.Context) {
+		t.createServiceExport(ctx, &clients[0], t.helloServiceExport)
 
 		// The conflict resolution policy in the MCS spec (KEP 1645) allows an implementation to favor maintaining
 		// service continuity and avoiding potentially disruptive changes, as such, an implementation may choose the
 		// first observed exported service when resolving conflicts. To support this, verify the ServiceImport is
 		// created on the first cluster prior to deploying on the second cluster.
-		t.awaitServiceImport(&clients[0], helloServiceName, false, nil)
+		t.awaitServiceImport(ctx, &clients[0], helloServiceName, false, nil)
 
 		// Delay a little before deploying on the second cluster to ensure the first cluster's ServiceExport timestamp
 		// is older so conflict checking is deterministic for implementations that use the timestamp when resolving conflicts.
 		// Make the delay at least 1 sec as creation timestamps have seconds granularity.
 		time.Sleep(1100 * time.Millisecond)
 
-		t.deployHelloService(&clients[1], tt.helloService2)
-		t.createServiceExport(&clients[1], tt.helloServiceExport2)
+		t.deployHelloService(ctx, &clients[1], tt.helloService2)
+		t.createServiceExport(ctx, &clients[1], tt.helloServiceExport2)
 	})
 
 	return tt

--- a/conformance/connectivity.go
+++ b/conformance/connectivity.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conformance
 
 import (
+	"context"
 	"fmt"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -57,14 +58,14 @@ var _ = Describe("", func() {
 	})
 
 	Context("Connectivity to an exported ClusterIP service", func() {
-		It("should be accessible through DNS", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel), func() {
+		It("should be accessible through DNS", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel), func(ctx context.Context) {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 			By("Exporting the service", func() {
 				// On the "remote" cluster
-				t.createServiceExport(&clients[0], newHelloServiceExport())
+				t.createServiceExport(ctx, &clients[0], newHelloServiceExport())
 			})
 			By("Issuing a request from all clusters", func() {
-				t.execPortConnectivityCommand(42, "pod ip", 1)
+				t.execPortConnectivityCommand(ctx, 42, "pod ip", 1)
 			})
 		})
 	})
@@ -74,20 +75,20 @@ var _ = Describe("", func() {
 			requireTwoClusters()
 		})
 
-		JustBeforeEach(func() {
-			t.deployHelloService(&clients[1], newHelloService())
+		JustBeforeEach(func(ctx context.Context) {
+			t.deployHelloService(ctx, &clients[1], newHelloService())
 		})
 
-		It("should only access the exporting cluster", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel), func() {
+		It("should only access the exporting cluster", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel), func(ctx context.Context) {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#exporting-services")
 
 			By(fmt.Sprintf("Exporting the service on cluster %q", clients[0].name))
 
-			t.createServiceExport(&clients[0], newHelloServiceExport())
+			t.createServiceExport(ctx, &clients[0], newHelloServiceExport())
 
-			servicePodIP := t.awaitServicePodIP(&clients[0])
+			servicePodIP := t.awaitServicePodIP(ctx, &clients[0])
 
-			t.execPortConnectivityCommand(42, servicePodIP, 10)
+			t.execPortConnectivityCommand(ctx, 42, servicePodIP, 10)
 		})
 	})
 
@@ -100,12 +101,12 @@ var _ = Describe("", func() {
 			}
 		})
 
-		It("should only route traffic to the cluster that exposes the port", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel, StrictPortConflictLabel), func() {
+		It("should only route traffic to the cluster that exposes the port", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel, StrictPortConflictLabel), func(ctx context.Context) {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port")
 
-			servicePodIP := t.awaitServicePodIP(&clients[0])
+			servicePodIP := t.awaitServicePodIP(ctx, &clients[0])
 
-			t.execPortConnectivityCommand(42, servicePodIP, 10)
+			t.execPortConnectivityCommand(ctx, 42, servicePodIP, 10)
 		})
 	})
 
@@ -118,14 +119,14 @@ var _ = Describe("", func() {
 			}
 		})
 
-		It("should route traffic to each port only to the cluster that exposes it", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel, StrictPortConflictLabel), func() {
+		It("should route traffic to each port only to the cluster that exposes it", Label(OptionalLabel, ConnectivityLabel, ClusterIPLabel, StrictPortConflictLabel), func(ctx context.Context) {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port")
 
-			cluster1PodIP := t.awaitServicePodIP(&clients[0])
-			cluster2PodIP := t.awaitServicePodIP(&clients[1])
+			cluster1PodIP := t.awaitServicePodIP(ctx, &clients[0])
+			cluster2PodIP := t.awaitServicePodIP(ctx, &clients[1])
 
-			t.execPortConnectivityCommand(42, cluster1PodIP, 10)
-			t.execPortConnectivityCommand(4242, cluster2PodIP, 10)
+			t.execPortConnectivityCommand(ctx, 42, cluster1PodIP, 10)
+			t.execPortConnectivityCommand(ctx, 4242, cluster2PodIP, 10)
 		})
 	})
 })

--- a/conformance/endpoint_slice.go
+++ b/conformance/endpoint_slice.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conformance
 
 import (
+	"context"
 	"fmt"
 	"time"
 
@@ -37,12 +38,12 @@ var _ = Describe("", Label(OptionalLabel, EndpointSliceLabel), func() {
 	SpecifyWithSpecRef("Exporting a service should create an MCS EndpointSlice in the service's namespace in each cluster with the "+
 		"required MCS labels. Unexporting should delete the EndpointSlice.",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#using-endpointslice-objects-to-track-endpoints",
-		func() {
+		func(ctx context.Context) {
 			endpointSliceNames := make([][]string, len(clients))
 
 			for i, client := range clients {
-				for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
-					eps := t.awaitMCSEndpointSlice(&client, addressTypeOf(ipFamily), nil, reportNonConformant(fmt.Sprintf(
+				for _, ipFamily := range t.awaitServiceImportIPFamilies(ctx, &client) {
+					eps := t.awaitMCSEndpointSlice(ctx, &client, addressTypeOf(ipFamily), nil, reportNonConformant(fmt.Sprintf(
 						"an MCS EndpointSlice was not found on cluster %q. An MCS EndpointSlice is identified by the presence "+
 							"of the required MCS labels (%q and %q). "+
 							"If the MCS implementation does not use MCS EndpointSlices, you can specify a Ginkgo label filter using "+
@@ -67,14 +68,14 @@ var _ = Describe("", Label(OptionalLabel, EndpointSliceLabel), func() {
 				}
 			}
 
-			t.deleteServiceExport(&clients[0])
+			t.deleteServiceExport(ctx, &clients[0])
 
 			for i, client := range clients {
 				for _, name := range endpointSliceNames[i] {
-					Eventually(func() bool {
+					Eventually(func(ctx context.Context) bool {
 						_, err := client.k8s.DiscoveryV1().EndpointSlices(t.namespace).Get(ctx, name, metav1.GetOptions{})
 						return apierrors.IsNotFound(err)
-					}, 20*time.Second, 100*time.Millisecond).Should(BeTrue(),
+					}).WithContext(ctx).Within(20*time.Second).ProbeEvery(100*time.Millisecond).Should(BeTrue(),
 						reportNonConformant(fmt.Sprintf("the EndpointSlice %q was not deleted on unexport from cluster %q",
 							name, client.name)))
 				}
@@ -82,7 +83,7 @@ var _ = Describe("", Label(OptionalLabel, EndpointSliceLabel), func() {
 		})
 })
 
-func (t *testDriver) awaitMCSEndpointSlice(c *clusterClients, addressType discoveryv1.AddressType,
+func (t *testDriver) awaitMCSEndpointSlice(ctx context.Context, c *clusterClients, addressType discoveryv1.AddressType,
 	verify func(Gomega, *discoveryv1.EndpointSlice), desc ...any) *discoveryv1.EndpointSlice {
 	By(fmt.Sprintf("Retrieving %s MCS EndpointSlice for the service on cluster %q", addressType, c.name))
 
@@ -93,7 +94,7 @@ func (t *testDriver) awaitMCSEndpointSlice(c *clusterClients, addressType discov
 		return exists
 	}
 
-	Eventually(func(g Gomega) {
+	Eventually(func(g Gomega, ctx context.Context) {
 		list, err := c.k8s.DiscoveryV1().EndpointSlices(t.namespace).List(ctx, metav1.ListOptions{})
 		g.Expect(err).ToNot(HaveOccurred(), "Error retrieving EndpointSlices")
 
@@ -115,7 +116,7 @@ func (t *testDriver) awaitMCSEndpointSlice(c *clusterClients, addressType discov
 
 		// The final run succeeded so cancel any prior non-conformance reported.
 		cancelNonConformanceReport()
-	}).Within(20 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+	}).WithContext(ctx).Within(20 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
 
 	return endpointSlice
 }

--- a/conformance/headless_service_dns.go
+++ b/conformance/headless_service_dns.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conformance
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 	"slices"
@@ -46,15 +47,15 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 	})
 
 	Specify("A DNS query of the <service>.<ns>.svc."+dnsDomain+" domain for a headless service should return the "+
-		"ready endpoint addresses of all the backing pods", func() {
+		"ready endpoint addresses of all the backing pods", func(ctx context.Context) {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
 		for _, client := range clients {
-			for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
+			for _, ipFamily := range t.awaitServiceImportIPFamilies(ctx, &client) {
 				command := []string{"sh", "-c", fmt.Sprintf("nslookup -type=%s %s.%s.svc.%s.", dnsRecordTypeOf(ipFamily),
 					t.helloService.Name, t.namespace, dnsDomain)}
 
-				endpoints := t.awaitK8sEndpoints(&clients[0], addressTypeOf(ipFamily))
+				endpoints := t.awaitK8sEndpoints(ctx, &clients[0], addressTypeOf(ipFamily))
 
 				var addresses []string
 				for _, ep := range endpoints {
@@ -73,18 +74,18 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 			t.helloDeployment = nil
 		})
 
-		JustBeforeEach(func() {
+		JustBeforeEach(func(ctx context.Context) {
 			_, err := clients[0].k8s.AppsV1().StatefulSets(t.namespace).Create(ctx, newStatefulSet(replicas), metav1.CreateOptions{})
 			Expect(err).ToNot(HaveOccurred())
 		})
 
 		Specify("A DNS query of the <hostname>.<clusterid>.<service>.<ns>.svc."+dnsDomain+" domain for a headless StatefulSet "+
-			"service should return the requested pod's endpoint address", Label(EndpointSliceLabel), func() {
+			"service should return the requested pod's endpoint address", Label(EndpointSliceLabel), func(ctx context.Context) {
 			AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
 			for _, client := range clients {
-				for _, ipFamily := range t.awaitServiceImportIPFamilies(&client) {
-					eps := t.awaitMCSEndpointSlice(&client, addressTypeOf(ipFamily), func(g Gomega, eps *discovery.EndpointSlice) {
+				for _, ipFamily := range t.awaitServiceImportIPFamilies(ctx, &client) {
+					eps := t.awaitMCSEndpointSlice(ctx, &client, addressTypeOf(ipFamily), func(g Gomega, eps *discovery.EndpointSlice) {
 						g.Expect(eps.Endpoints).To(HaveLen(replicas),
 							"the MCS EndpointSlice %q does not contain the expected number of endpoints %d",
 							eps.Name, replicas)
@@ -122,13 +123,13 @@ var _ = Describe("", Label(OptionalLabel, DNSLabel, HeadlessLabel), func() {
 	})
 
 	Specify("A DNS SRV query of the <service>.<ns>.svc."+dnsDomain+" domain for a headless service should return valid SRV "+
-		"records", func() {
+		"records", func(ctx context.Context) {
 		AddReportEntry(SpecRefReportEntry, "https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#dns")
 
 		// Collect endpoints for all IP families in the service (for dual-stack support)
 		var allEndpoints []endpointInfo
 		for _, ipFamily := range t.helloService.Spec.IPFamilies {
-			endpoints := t.awaitK8sEndpoints(&clients[0], addressTypeOf(ipFamily))
+			endpoints := t.awaitK8sEndpoints(ctx, &clients[0], addressTypeOf(ipFamily))
 			allEndpoints = append(allEndpoints, endpoints...)
 		}
 
@@ -162,12 +163,12 @@ func (e endpointInfo) String() string {
 	return fmt.Sprintf("address:%q, hostName:%q", e.address, e.hostName)
 }
 
-func (t *testDriver) awaitK8sEndpoints(c *clusterClients, addressType discovery.AddressType) []endpointInfo {
+func (t *testDriver) awaitK8sEndpoints(ctx context.Context, c *clusterClients, addressType discovery.AddressType) []endpointInfo {
 	By(fmt.Sprintf("Retrieving %s K8s endpoint addresses for the service on cluster %q", addressType, c.name))
 
 	var endpoints []endpointInfo
 
-	Eventually(func(g Gomega) {
+	Eventually(func(g Gomega, ctx context.Context) {
 		epsList, err := c.k8s.DiscoveryV1().EndpointSlices(t.namespace).List(ctx, metav1.ListOptions{
 			LabelSelector: labels.SelectorFromSet(map[string]string{
 				discovery.LabelServiceName: t.helloService.Name,
@@ -215,7 +216,7 @@ func (t *testDriver) awaitK8sEndpoints(c *clusterClients, addressType discovery.
 
 		// The final run succeeded so cancel any prior non-conformance reported.
 		cancelNonConformanceReport()
-	}).Within(20 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+	}).WithContext(ctx).Within(20 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
 
 	By(fmt.Sprintf("Found endpoints %v", endpoints))
 

--- a/conformance/service_import.go
+++ b/conformance/service_import.go
@@ -17,6 +17,7 @@ limitations under the License.
 package conformance
 
 import (
+	"context"
 	"fmt"
 	"net"
 	"time"
@@ -57,32 +58,32 @@ func testGeneralServiceImport() {
 	// exports a service from two clusters and ensures proper behavior when unexported from both.
 	SpecifyWithSpecRef("A ServiceImport should only exist as long as there's at least one exporting cluster",
 		"https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#importing-services",
-		Label(RequiredLabel), func() {
+		Label(RequiredLabel), func(ctx context.Context) {
 			requireTwoClusters()
 
-			t.awaitServiceImport(&clients[0], t.helloService.Name, false, nil)
+			t.awaitServiceImport(ctx, &clients[0], t.helloService.Name, false, nil)
 
 			By(fmt.Sprintf("Exporting the service on the second cluster %q", clients[1].name))
 
-			t.deployHelloService(&clients[1], newHelloService())
-			t.createServiceExport(&clients[1], newHelloServiceExport())
+			t.deployHelloService(ctx, &clients[1], newHelloService())
+			t.createServiceExport(ctx, &clients[1], newHelloServiceExport())
 
 			// Sanity check and to also wait a bit for the second cluster to export. There's no deterministic way to tell if/when
 			// the second cluster has finished exporting other than utilizing different service ports in each cluster but service
 			// port merging behavior is already covered in another test case, so it's ideal not to rely on behavior that could
 			// cause orthogonal failures and to avoid duplicate testing.
-			t.ensureServiceImport(&clients[0], t.helloService.Name, fmt.Sprintf(
+			t.ensureServiceImport(ctx, &clients[0], t.helloService.Name, fmt.Sprintf(
 				"the ServiceImport no longer exists after exporting on cluster %q", clients[1].name))
 
-			t.deleteServiceExport(&clients[0])
+			t.deleteServiceExport(ctx, &clients[0])
 
-			t.ensureServiceImport(&clients[0], t.helloService.Name, fmt.Sprintf(
+			t.ensureServiceImport(ctx, &clients[0], t.helloService.Name, fmt.Sprintf(
 				"the ServiceImport no longer exists after unexporting the service on cluster %q while still exported on cluster %q",
 				clients[0].name, clients[1].name))
 
-			t.deleteServiceExport(&clients[1])
+			t.deleteServiceExport(ctx, &clients[1])
 
-			t.awaitNoServiceImport(&clients[0], helloServiceName,
+			t.awaitNoServiceImport(ctx, &clients[0], helloServiceName,
 				"the ServiceImport still exists after unexporting the service on all clusters")
 		})
 
@@ -94,8 +95,8 @@ func testGeneralServiceImport() {
 
 		SpecifyWithSpecRef("Only labels and annotations specified as exported in the ServiceExport should be propagated to the ServiceImport",
 			"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#labels-and-annotations",
-			Label(OptionalLabel), Label(ExportedLabelsLabel), func() {
-				t.awaitServiceImport(&clients[0], helloServiceName, false,
+			Label(OptionalLabel), Label(ExportedLabelsLabel), func(ctx context.Context) {
+				t.awaitServiceImport(ctx, &clients[0], helloServiceName, false,
 					func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 						assertHasKeyValues(g, serviceImport.Annotations, t.helloServiceExport.Spec.ExportedAnnotations)
 						assertNotHasKeyValues(g, serviceImport.Annotations, t.helloService.Annotations)
@@ -120,11 +121,11 @@ func testGeneralServiceImport() {
 
 			SpecifyWithSpecRef("should apply the conflict resolution policy and report a Conflict condition on each ServiceExport",
 				"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#labels-and-annotations",
-				Label(OptionalLabel), Label(ExportedLabelsLabel), func() {
-					t.awaitServiceExportCondition(&clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
-					t.awaitServiceExportCondition(&clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+				Label(OptionalLabel), Label(ExportedLabelsLabel), func(ctx context.Context) {
+					t.awaitServiceExportCondition(ctx, &clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+					t.awaitServiceExportCondition(ctx, &clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
 
-					t.awaitServiceImport(&clients[0], t.helloService.Name, false,
+					t.awaitServiceImport(ctx, &clients[0], t.helloService.Name, false,
 						func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 							assertHasKeyValues(g, serviceImport.Annotations, t.helloServiceExport.Spec.ExportedAnnotations)
 							assertNotHasKeyValues(g, serviceImport.Annotations, tt.helloServiceExport2.Spec.ExportedAnnotations)
@@ -143,28 +144,28 @@ func testClusterIPServiceImport() {
 	SpecifyWithSpecRef("Exporting a ClusterIP service should create a ServiceImport of type ClusterSetIP in the service's namespace in each cluster. "+
 		"Unexporting should delete the ServiceImport",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#importing-services",
-		Label(RequiredLabel), func() {
-			t.awaitServiceExportCondition(&clients[0], v1beta1.ServiceExportConditionValid, metav1.ConditionTrue)
+		Label(RequiredLabel), func(ctx context.Context) {
+			t.awaitServiceExportCondition(ctx, &clients[0], v1beta1.ServiceExportConditionValid, metav1.ConditionTrue)
 
 			for i := range clients {
-				serviceImport := t.awaitServiceImport(&clients[i], helloServiceName, true, nil)
+				serviceImport := t.awaitServiceImport(ctx, &clients[i], helloServiceName, true, nil)
 
 				Expect(serviceImport.Spec.Type).To(Equal(v1beta1.ClusterSetIP), reportNonConformant(
 					fmt.Sprintf("ServiceImport on cluster %q has type %q", clients[i].name, serviceImport.Spec.Type)))
 			}
 
-			t.deleteServiceExport(&clients[0])
+			t.deleteServiceExport(ctx, &clients[0])
 
 			for i := range clients {
-				t.awaitNoServiceImport(&clients[i], helloServiceName, fmt.Sprintf(
+				t.awaitNoServiceImport(ctx, &clients[i], helloServiceName, fmt.Sprintf(
 					"the ServiceImport still exists on cluster %q after unexporting the service", clients[i].name))
 			}
 		})
 
 	SpecifyWithSpecRef("The SessionAffinity for a ClusterSetIP ServiceImport should match the exported service's SessionAffinity",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#session-affinity",
-		Label(RequiredLabel), func() {
-			t.awaitServiceImport(&clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
+		Label(RequiredLabel), func(ctx context.Context) {
+			t.awaitServiceImport(ctx, &clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 				g.Expect(serviceImport.Spec.SessionAffinity).To(Equal(t.helloService.Spec.SessionAffinity), reportNonConformant(""))
 
 				g.Expect(serviceImport.Spec.SessionAffinityConfig).To(Equal(t.helloService.Spec.SessionAffinityConfig), reportNonConformant(
@@ -178,8 +179,8 @@ func testClusterIPServiceImport() {
 		})
 		SpecifyWithSpecRef("The InternalTrafficPolicy for a ClusterSetIP ServiceImport should match the exported service's InternalTrafficPolicy",
 			"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#internal-traffic-policy",
-			Label(RequiredLabel), func() {
-				t.awaitServiceImport(&clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
+			Label(RequiredLabel), func(ctx context.Context) {
+				t.awaitServiceImport(ctx, &clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 					g.Expect(serviceImport.Spec.InternalTrafficPolicy).To(Equal(t.helloService.Spec.InternalTrafficPolicy), reportNonConformant(
 						"The InternalTrafficPolicy of the ServiceImport does not match the exported Service's InternalTrafficPolicy"))
 				})
@@ -193,8 +194,8 @@ func testClusterIPServiceImport() {
 		})
 		SpecifyWithSpecRef("The TrafficDistribution for a ClusterSetIP ServiceImport should match the exported service's TrafficDistribution",
 			"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#traffic-distribution",
-			Label(RequiredLabel), func() {
-				t.awaitServiceImport(&clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
+			Label(RequiredLabel), func(ctx context.Context) {
+				t.awaitServiceImport(ctx, &clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 					g.Expect(serviceImport.Spec.TrafficDistribution).To(Equal(t.helloService.Spec.TrafficDistribution), reportNonConformant(
 						"The TrafficDistribution of the ServiceImport does not match the exported Service's TrafficDistribution"))
 				})
@@ -204,8 +205,8 @@ func testClusterIPServiceImport() {
 
 	SpecifyWithSpecRef("An IP should be allocated for a ClusterSetIP ServiceImport for each IP family",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#clustersetip",
-		Label(RequiredLabel), func() {
-			serviceImport := t.awaitServiceImport(&clients[0], t.helloService.Name, false,
+		Label(RequiredLabel), func(ctx context.Context) {
+			serviceImport := t.awaitServiceImport(ctx, &clients[0], t.helloService.Name, false,
 				func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 					g.Expect(serviceImport.Spec.IPs).ToNot(BeEmpty(), reportNonConformant(""))
 				})
@@ -227,8 +228,8 @@ func testClusterIPServiceImport() {
 
 	SpecifyWithSpecRef("The ports for a ClusterSetIP ServiceImport should match those of the exported service",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port",
-		Label(RequiredLabel), func() {
-			t.awaitServiceImport(&clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
+		Label(RequiredLabel), func(ctx context.Context) {
+			t.awaitServiceImport(ctx, &clients[0], helloServiceName, false, func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 				g.Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(t.helloService.Spec.Ports)), reportNonConformant(""))
 			})
 		})
@@ -250,11 +251,11 @@ func testClusterIPServiceImport() {
 
 			SpecifyWithSpecRef("should expose the union of the constituent service ports and raise a conflict",
 				"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port",
-				Label(RequiredLabel), func() {
-					t.awaitServiceExportCondition(&clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
-					t.awaitServiceExportCondition(&clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+				Label(RequiredLabel), func(ctx context.Context) {
+					t.awaitServiceExportCondition(ctx, &clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+					t.awaitServiceExportCondition(ctx, &clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
 
-					t.awaitServiceImport(&clients[0], t.helloService.Name, false,
+					t.awaitServiceImport(ctx, &clients[0], t.helloService.Name, false,
 						func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 							g.Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(
 								append(t.helloService.Spec.Ports, tt.helloService2.Spec.Ports[1]))), reportNonConformant(""))
@@ -270,11 +271,11 @@ func testClusterIPServiceImport() {
 
 			SpecifyWithSpecRef("should apply the conflict resolution policy and report a Conflict condition on each ServiceExport",
 				"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-port",
-				func() {
-					t.awaitServiceExportCondition(&clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
-					t.awaitServiceExportCondition(&clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+				func(ctx context.Context) {
+					t.awaitServiceExportCondition(ctx, &clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+					t.awaitServiceExportCondition(ctx, &clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
 
-					t.awaitServiceImport(&clients[0], t.helloService.Name, false,
+					t.awaitServiceImport(ctx, &clients[0], t.helloService.Name, false,
 						func(g Gomega, serviceImport *v1beta1.ServiceImport) {
 							g.Expect(sortMCSPorts(serviceImport.Spec.Ports)).To(Equal(toMCSPorts(t.helloService.Spec.Ports)),
 								reportNonConformant("The service ports were not resolved correctly"))
@@ -294,29 +295,29 @@ func testHeadlessServiceImport() {
 	SpecifyWithSpecRef("Exporting a headless service should create a ServiceImport of type Headless in the service's namespace in each cluster. "+
 		"Unexporting should delete the ServiceImport",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#service-types",
-		Label(RequiredLabel), func() {
+		Label(RequiredLabel), func(ctx context.Context) {
 			for i := range clients {
-				serviceImport := t.awaitServiceImport(&clients[i], helloServiceName, true, nil)
+				serviceImport := t.awaitServiceImport(ctx, &clients[i], helloServiceName, true, nil)
 
 				Expect(serviceImport.Spec.Type).To(Equal(v1beta1.Headless), reportNonConformant(
 					fmt.Sprintf("ServiceImport on cluster %q has type %q", clients[i].name, serviceImport.Spec.Type)))
 			}
 
-			t.deleteServiceExport(&clients[0])
+			t.deleteServiceExport(ctx, &clients[0])
 
 			for i := range clients {
-				t.awaitNoServiceImport(&clients[i], helloServiceName, fmt.Sprintf(
+				t.awaitNoServiceImport(ctx, &clients[i], helloServiceName, fmt.Sprintf(
 					"the ServiceImport still exists on cluster %q after unexporting the service", clients[i].name))
 			}
 		})
 
 	SpecifyWithSpecRef("No clusterset IP should be allocated for a Headless ServiceImport",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#clustersetip",
-		Label(RequiredLabel), func() {
-			t.awaitServiceImport(&clients[0], t.helloService.Name, false, nil)
+		Label(RequiredLabel), func(ctx context.Context) {
+			t.awaitServiceImport(ctx, &clients[0], t.helloService.Name, false, nil)
 
 			Consistently(func() []string {
-				return t.getServiceImport(&clients[0], t.helloService.Name).Spec.IPs
+				return t.getServiceImport(ctx, &clients[0], t.helloService.Name).Spec.IPs
 			}).Within(5*time.Second).ProbeEvery(time.Second).Should(BeEmpty(), reportNonConformant(""))
 		})
 }
@@ -332,9 +333,9 @@ func testExternalNameService() {
 
 	SpecifyWithSpecRef("Exporting an ExternalName service should set ServiceExport Valid condition to False",
 		"https://github.com/kubernetes/enhancements/blob/master/keps/sig-multicluster/1645-multi-cluster-services-api/README.md#service-types",
-		Label(RequiredLabel), func() {
-			t.awaitServiceExportCondition(&clients[0], v1beta1.ServiceExportConditionValid, metav1.ConditionFalse)
-			t.ensureNoServiceImport(&clients[0], helloServiceName,
+		Label(RequiredLabel), func(ctx context.Context) {
+			t.awaitServiceExportCondition(ctx, &clients[0], v1beta1.ServiceExportConditionValid, metav1.ConditionFalse)
+			t.ensureNoServiceImport(ctx, &clients[0], helloServiceName,
 				"the ServiceImport should not exist for an ExternalName service")
 		})
 }
@@ -349,12 +350,12 @@ func testServiceTypeConflict() {
 	SpecifyWithSpecRef("A service exported on two clusters with conflicting headlessness should apply the conflict resolution policy and "+
 		"report a Conflict condition on the ServiceExport",
 		"https://github.com/kubernetes/enhancements/tree/master/keps/sig-multicluster/1645-multi-cluster-services-api#headlessness",
-		Label(RequiredLabel), func() {
-			t.awaitServiceExportCondition(&clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
-			t.awaitServiceExportCondition(&clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+		Label(RequiredLabel), func(ctx context.Context) {
+			t.awaitServiceExportCondition(ctx, &clients[0], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
+			t.awaitServiceExportCondition(ctx, &clients[1], v1beta1.ServiceExportConditionConflict, metav1.ConditionTrue)
 
 			for i := range clients {
-				serviceImport := t.awaitServiceImport(&clients[i], helloServiceName, true, nil)
+				serviceImport := t.awaitServiceImport(ctx, &clients[i], helloServiceName, true, nil)
 
 				Expect(serviceImport.Spec.Type).To(Equal(v1beta1.ClusterSetIP), reportNonConformant(
 					fmt.Sprintf("ServiceImport on cluster %q has type %q", clients[i].name, serviceImport.Spec.Type)))


### PR DESCRIPTION
Ginkgo provides its own context, using that instead of a shared context.TODO() provides better support for cancellation etc.