### PR TITLE
conformance: increase timeout for pods start up

### DIFF
--- a/conformance/conformance_suite.go
+++ b/conformance/conformance_suite.go
@@ -349,7 +349,7 @@ func (t *testDriver) startRequestPod(ctx context.Context, client clusterClients)
 		}
 
 		return nil
-	}, 20, 1).Should(Succeed())
+	}, 60, 1).Should(Succeed())
 }
 
 func (t *testDriver) execCmdOnRequestPod(c *clusterClients, command []string) string {
@@ -388,7 +388,7 @@ func (t *testDriver) awaitServicePodIP(ctx context.Context, c *clusterClients) s
 
 		servicePodIP = pods.Items[0].Status.PodIP
 		g.Expect(servicePodIP).NotTo(BeEmpty(), "Service deployment pod was not allocated an IP")
-	}).WithContext(ctx).Within(20 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
+	}).WithContext(ctx).Within(60 * time.Second).WithPolling(100 * time.Millisecond).Should(Succeed())
 
 	By(fmt.Sprintf("Retrieved service deployment pod IP %q", servicePodIP))
 

--- a/conformance/endpoint_slice.go
+++ b/conformance/endpoint_slice.go
@@ -116,7 +116,7 @@ func (t *testDriver) awaitMCSEndpointSlice(ctx context.Context, c *clusterClient
 
 		// The final run succeeded so cancel any prior non-conformance reported.
 		cancelNonConformanceReport()
-	}).WithContext(ctx).Within(20 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+	}).WithContext(ctx).Within(60 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
 
 	return endpointSlice
 }

--- a/conformance/headless_service_dns.go
+++ b/conformance/headless_service_dns.go
@@ -216,7 +216,7 @@ func (t *testDriver) awaitK8sEndpoints(ctx context.Context, c *clusterClients, a
 
 		// The final run succeeded so cancel any prior non-conformance reported.
 		cancelNonConformanceReport()
-	}).WithContext(ctx).Within(20 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
+	}).WithContext(ctx).Within(60 * time.Second).ProbeEvery(100 * time.Millisecond).Should(Succeed())
 
 	By(fmt.Sprintf("Found endpoints %v", endpoints))
 


### PR DESCRIPTION
In Cilium we are running this conformance test in CI and have seen about ~10-15% of failure and most of them could be attributed to a timeout waiting for a Pod to be ready.

Thus, this commit increase all occurrences in the conformance suite that actively wait for a pod to be ready (and related EndpointSlices) from 20s to 60s. This should let us know that that something is actually wrong with pod startup while not being too generous either.