### PR TITLE
Add multicluster category to CRDs

### DIFF
--- a/config/crd-base/multicluster.x-k8s.io_serviceexports.yaml
+++ b/config/crd-base/multicluster.x-k8s.io_serviceexports.yaml
@@ -20,11 +20,13 @@ metadata:
     # The revision is updated on each CRD change and reset back to 0 on every new version.
     # It can be used together with the version label when installing those CRDs
     # and prevent any downgrades.
-    multicluster.x-k8s.io/crd-schema-revision: "0"
+    multicluster.x-k8s.io/crd-schema-revision: "1"
 spec:
   group: multicluster.x-k8s.io
   scope: Namespaced
   names:
+    categories:
+    - multicluster
     plural: serviceexports
     singular: serviceexport
     kind: ServiceExport

--- a/config/crd-base/multicluster.x-k8s.io_serviceimports.yaml
+++ b/config/crd-base/multicluster.x-k8s.io_serviceimports.yaml
@@ -20,11 +20,13 @@ metadata:
     # The revision is updated on each CRD change and reset back to 0 on every new version.
     # It can be used together with the version label when installing those CRDs
     # and prevent any downgrades.
-    multicluster.x-k8s.io/crd-schema-revision: "0"
+    multicluster.x-k8s.io/crd-schema-revision: "1"
 spec:
   group: multicluster.x-k8s.io
   scope: Namespaced
   names:
+    categories:
+    - multicluster
     plural: serviceimports
     singular: serviceimport
     kind: ServiceImport

--- a/config/crd/multicluster.x-k8s.io_serviceexports.yaml
+++ b/config/crd/multicluster.x-k8s.io_serviceexports.yaml
@@ -20,11 +20,13 @@ metadata:
     # The revision is updated on each CRD change and reset back to 0 on every new version.
     # It can be used together with the version label when installing those CRDs
     # and prevent any downgrades.
-    multicluster.x-k8s.io/crd-schema-revision: "0"
+    multicluster.x-k8s.io/crd-schema-revision: "1"
 spec:
   group: multicluster.x-k8s.io
   scope: Namespaced
   names:
+    categories:
+      - multicluster
     plural: serviceexports
     singular: serviceexport
     kind: ServiceExport

--- a/config/crd/multicluster.x-k8s.io_serviceimports.yaml
+++ b/config/crd/multicluster.x-k8s.io_serviceimports.yaml
@@ -20,11 +20,13 @@ metadata:
     # The revision is updated on each CRD change and reset back to 0 on every new version.
     # It can be used together with the version label when installing those CRDs
     # and prevent any downgrades.
-    multicluster.x-k8s.io/crd-schema-revision: "0"
+    multicluster.x-k8s.io/crd-schema-revision: "1"
 spec:
   group: multicluster.x-k8s.io
   scope: Namespaced
   names:
+    categories:
+      - multicluster
     plural: serviceimports
     singular: serviceimport
     kind: ServiceImport

--- a/pkg/apis/v1alpha1/serviceexport.go
+++ b/pkg/apis/v1alpha1/serviceexport.go
@@ -34,7 +34,7 @@ var ServiceExportVersionedName = ServiceExportKindName + "/" + GroupVersion.Vers
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName={svcex,svcexport}
+// +kubebuilder:resource:shortName={svcex,svcexport},categories=multicluster
 
 // ServiceExport declares that the Service with the same name and namespace
 // as this export should be consumable from other clusters.

--- a/pkg/apis/v1alpha1/serviceimport.go
+++ b/pkg/apis/v1alpha1/serviceimport.go
@@ -35,7 +35,7 @@ var ServiceImportVersionedName = ServiceImportKindName + "/" + GroupVersion.Vers
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName={svcim,svcimport}
+// +kubebuilder:resource:shortName={svcim,svcimport},categories=multicluster
 
 // ServiceImport describes a service imported from clusters in a ClusterSet.
 type ServiceImport struct {

--- a/pkg/apis/v1beta1/serviceexport.go
+++ b/pkg/apis/v1beta1/serviceexport.go
@@ -34,7 +34,7 @@ var ServiceExportVersionedName = ServiceExportKindName + "/" + GroupVersion.Vers
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName={svcex,svcexport}
+// +kubebuilder:resource:shortName={svcex,svcexport},categories=multicluster
 // +kubebuilder:storageversion
 
 // ServiceExport declares that the Service with the same name and namespace

--- a/pkg/apis/v1beta1/serviceimport.go
+++ b/pkg/apis/v1beta1/serviceimport.go
@@ -35,7 +35,7 @@ var ServiceImportVersionedName = ServiceImportKindName + "/" + GroupVersion.Vers
 
 // +genclient
 // +kubebuilder:object:root=true
-// +kubebuilder:resource:shortName={svcim,svcimport}
+// +kubebuilder:resource:shortName={svcim,svcimport},categories=multicluster
 // +kubebuilder:storageversion
 
 // ServiceImport describes a service imported from clusters in a ClusterSet.


### PR DESCRIPTION
## Summary

Add the `multicluster` category to the MCS API CRDs.

## Background

Following [this discussion](https://github.com/kubernetes-sigs/cluster-inventory-api/pull/80#issuecomment-5071886576), SIG Multicluster CRDs should use a common category. This allows users to list these resources together with `kubectl get multicluster`.
