### PR TITLE
Update reviewers

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -5,11 +5,8 @@ reviewers:
   - lauralorenz
   - skitt
   - MrFreezeex
-  - munnerz
   - RainbowMango
   - ryanzhang-oss
-# Pending org membership
-# - jnpacker
 
 approvers:
   - JeremyOT

--- a/OWNERS
+++ b/OWNERS
@@ -7,6 +7,7 @@ reviewers:
   - MrFreezeex
   - RainbowMango
   - ryanzhang-oss
+  - tpantelis
 
 approvers:
   - JeremyOT


### PR DESCRIPTION
As discussed in the September 1 SIG call, this drops inactive reviewers and adds @tpantelis.