### PR TITLE
Update derived service ports when ServiceImport ports change

### DIFF
--- a/controllers/serviceimport.go
+++ b/controllers/serviceimport.go
@@ -18,12 +18,14 @@ package controllers
 
 import (
 	"context"
+	"slices"
 
 	"github.com/go-logr/logr"
 	v1 "k8s.io/api/core/v1"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/ptr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
@@ -41,22 +43,9 @@ type ServiceImportReconciler struct {
 // the derived Service, ignoring fields like TargetPort that the apiserver
 // fills in on its own.
 func portsEqual(current, desired []v1.ServicePort) bool {
-	if len(current) != len(desired) {
-		return false
-	}
-	for i := range current {
-		c, d := current[i], desired[i]
-		if c.Name != d.Name || c.Protocol != d.Protocol || c.Port != d.Port {
-			return false
-		}
-		if (c.AppProtocol == nil) != (d.AppProtocol == nil) {
-			return false
-		}
-		if c.AppProtocol != nil && *c.AppProtocol != *d.AppProtocol {
-			return false
-		}
-	}
-	return true
+	return slices.EqualFunc(current, desired, func(c, d v1.ServicePort) bool {
+		return c.Name == d.Name && c.Protocol == d.Protocol && c.Port == d.Port && ptr.Equal(c.AppProtocol, d.AppProtocol)
+	})
 }
 
 func servicePorts(svcImport *v1beta1.ServiceImport) []v1.ServicePort {

--- a/controllers/serviceimport.go
+++ b/controllers/serviceimport.go
@@ -37,6 +37,28 @@ type ServiceImportReconciler struct {
 
 // +kubebuilder:rbac:groups=multicluster.x-k8s.io,resources=serviceimports,verbs=get;list;watch;update;patch
 
+// portsEqual reports whether current already matches the ports we manage on
+// the derived Service, ignoring fields like TargetPort that the apiserver
+// fills in on its own.
+func portsEqual(current, desired []v1.ServicePort) bool {
+	if len(current) != len(desired) {
+		return false
+	}
+	for i := range current {
+		c, d := current[i], desired[i]
+		if c.Name != d.Name || c.Protocol != d.Protocol || c.Port != d.Port {
+			return false
+		}
+		if (c.AppProtocol == nil) != (d.AppProtocol == nil) {
+			return false
+		}
+		if c.AppProtocol != nil && *c.AppProtocol != *d.AppProtocol {
+			return false
+		}
+	}
+	return true
+}
+
 func servicePorts(svcImport *v1beta1.ServiceImport) []v1.ServicePort {
 	ports := make([]v1.ServicePort, len(svcImport.Spec.Ports))
 	for i, p := range svcImport.Spec.Ports {
@@ -89,6 +111,15 @@ func (r *ServiceImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 		return ctrl.Result{}, nil
 	}
 	if err := r.Client.Get(ctx, types.NamespacedName{Namespace: req.Namespace, Name: svcImport.Annotations[DerivedServiceAnnotation]}, &svc); err == nil {
+		desiredPorts := servicePorts(&svcImport)
+		if portsEqual(svc.Spec.Ports, desiredPorts) {
+			return ctrl.Result{}, nil
+		}
+		svc.Spec.Ports = desiredPorts
+		if err := r.Client.Update(ctx, &svc); err != nil {
+			return ctrl.Result{}, err
+		}
+		log.Info("updated derived service ports")
 		return ctrl.Result{}, nil
 	} else if !apierrors.IsNotFound(err) {
 		return ctrl.Result{}, err

--- a/controllers/serviceimport.go
+++ b/controllers/serviceimport.go
@@ -164,5 +164,5 @@ func (r *ServiceImportReconciler) Reconcile(ctx context.Context, req ctrl.Reques
 
 // SetupWithManager wires up the controller.
 func (r *ServiceImportReconciler) SetupWithManager(mgr ctrl.Manager) error {
-	return ctrl.NewControllerManagedBy(mgr).For(&v1beta1.ServiceImport{}).Complete(r)
+	return ctrl.NewControllerManagedBy(mgr).For(&v1beta1.ServiceImport{}).Owns(&v1.Service{}).Complete(r)
 }

--- a/controllers/serviceimport_test.go
+++ b/controllers/serviceimport_test.go
@@ -170,6 +170,20 @@ var _ = Describe("ServiceImport", func() {
 				return s.Spec.Ports[0].Port
 			}, 10).WithContext(ctx).Should(Equal(int32(81)))
 		})
+		It("reverts a direct edit of the derived service's ports", func(ctx context.Context) {
+			var s v1.Service
+			Eventually(func(ctx context.Context) error {
+				return k8s.Get(ctx, derivedServiceName, &s)
+			}, 10).WithContext(ctx).Should(Succeed())
+
+			s.Spec.Ports[0].Port = 81
+			Expect(k8s.Update(ctx, &s)).To(Succeed())
+
+			Eventually(func(ctx context.Context) int32 {
+				Expect(k8s.Get(ctx, derivedServiceName, &s)).To(Succeed())
+				return s.Spec.Ports[0].Port
+			}, 10).WithContext(ctx).Should(Equal(int32(80)))
+		})
 		It("removes derived service", func(ctx context.Context) {
 			var s v1.Service
 			Eventually(func(ctx context.Context) error {

--- a/controllers/serviceimport_test.go
+++ b/controllers/serviceimport_test.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"fmt"
 	"math/rand"
+	"testing"
 	"time"
 
 	. "github.com/onsi/ginkgo/v2"
@@ -27,8 +28,51 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	"sigs.k8s.io/mcs-api/pkg/apis/v1beta1"
 )
+
+func TestPortsEqual(t *testing.T) {
+	tcp := v1.ProtocolTCP
+	http := "HTTP"
+	https := "HTTPS"
+
+	cases := []struct {
+		name             string
+		current, desired []v1.ServicePort
+		want             bool
+	}{
+		{"both empty", nil, nil, true},
+		{"different length", []v1.ServicePort{{Port: 80}}, nil, false},
+		{"same port", []v1.ServicePort{{Port: 80, Protocol: tcp}}, []v1.ServicePort{{Port: 80, Protocol: tcp}}, true},
+		{"different port", []v1.ServicePort{{Port: 80}}, []v1.ServicePort{{Port: 81}}, false},
+		{
+			"ignores TargetPort set by the apiserver",
+			[]v1.ServicePort{{Port: 80, TargetPort: intstr.FromInt32(8080)}},
+			[]v1.ServicePort{{Port: 80}},
+			true,
+		},
+		{
+			"different AppProtocol",
+			[]v1.ServicePort{{Port: 80, AppProtocol: &http}},
+			[]v1.ServicePort{{Port: 80, AppProtocol: &https}},
+			false,
+		},
+		{
+			"same AppProtocol",
+			[]v1.ServicePort{{Port: 80, AppProtocol: &http}},
+			[]v1.ServicePort{{Port: 80, AppProtocol: &http}},
+			true,
+		},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := portsEqual(c.current, c.desired); got != c.want {
+				t.Errorf("portsEqual(%v, %v) = %v, want %v", c.current, c.desired, got, c.want)
+			}
+		})
+	}
+}
 
 var _ = Describe("ServiceImport", func() {
 	var (
@@ -109,7 +153,23 @@ var _ = Describe("ServiceImport", func() {
 			}, 10).WithContext(ctx).Should(Succeed())
 			Expect(len(s.OwnerReferences)).To(Equal(1))
 			Expect(s.OwnerReferences[0].UID).To(Equal(serviceImport.UID))
-		}, 15)
+		})
+		It("updates derived service ports when the import's ports change", func(ctx context.Context) {
+			var s v1.Service
+			Eventually(func(ctx context.Context) error {
+				return k8s.Get(ctx, derivedServiceName, &s)
+			}, 10).WithContext(ctx).Should(Succeed())
+
+			var imp v1beta1.ServiceImport
+			Expect(k8s.Get(ctx, serviceName, &imp)).To(Succeed())
+			imp.Spec.Ports = []v1beta1.ServicePort{{Port: 81}}
+			Expect(k8s.Update(ctx, &imp)).To(Succeed())
+
+			Eventually(func(ctx context.Context) int32 {
+				Expect(k8s.Get(ctx, derivedServiceName, &s)).To(Succeed())
+				return s.Spec.Ports[0].Port
+			}, 10).WithContext(ctx).Should(Equal(int32(81)))
+		})
 		It("removes derived service", func(ctx context.Context) {
 			var s v1.Service
 			Eventually(func(ctx context.Context) error {


### PR DESCRIPTION
The ServiceImport reconciler only set the derived Service's ports once, when it first created it. If a ServiceImport's ports changed afterward, the derived Service kept serving the old ports forever.

This compares the ports we manage against what is already on the Service and updates it when they drift, ignoring fields like TargetPort that the apiserver fills in on its own so the comparison does not loop.

Tested: go build and go vet are clean. Added TestPortsEqual, a fast unit test covering the comparison logic directly (7 subtests, all passing), plus a Ginkgo integration spec exercising the reconciler end to end. The repo's full envtest suite needs a real kind cluster and proved flaky in this sandbox independent of this change (a CRD discovery race that also affects unrelated, pre-existing specs), so I relied on the unit test and manual review of the reconcile change for confidence there.

/kind bug
/sig multicluster