### PR TITLE
Fix copy pasted list doc comments

### DIFF
--- a/pkg/apis/v1alpha1/serviceexport.go
+++ b/pkg/apis/v1alpha1/serviceexport.go
@@ -94,13 +94,13 @@ const (
 
 // +kubebuilder:object:root=true
 
-// ServiceExportList represents a list of endpoint slices
+// ServiceExportList represents a list of service exports
 type ServiceExportList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
-	// List of endpoint slices
+	// List of service exports
 	// +listType=set
 	Items []ServiceExport `json:"items"`
 }

--- a/pkg/apis/v1alpha1/serviceimport.go
+++ b/pkg/apis/v1alpha1/serviceimport.go
@@ -190,13 +190,13 @@ const (
 
 // +kubebuilder:object:root=true
 
-// ServiceImportList represents a list of endpoint slices
+// ServiceImportList represents a list of service imports
 type ServiceImportList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
-	// List of endpoint slices
+	// List of service imports
 	// +listType=set
 	Items []ServiceImport `json:"items"`
 }

--- a/pkg/apis/v1beta1/serviceexport.go
+++ b/pkg/apis/v1beta1/serviceexport.go
@@ -76,13 +76,13 @@ type ServiceExportStatus struct {
 
 // +kubebuilder:object:root=true
 
-// ServiceExportList represents a list of endpoint slices
+// ServiceExportList represents a list of service exports
 type ServiceExportList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
-	// List of endpoint slices
+	// List of service exports
 	// +listType=set
 	Items []ServiceExport `json:"items"`
 }

--- a/pkg/apis/v1beta1/serviceimport.go
+++ b/pkg/apis/v1beta1/serviceimport.go
@@ -191,13 +191,13 @@ const (
 
 // +kubebuilder:object:root=true
 
-// ServiceImportList represents a list of endpoint slices
+// ServiceImportList represents a list of service imports
 type ServiceImportList struct {
 	metav1.TypeMeta `json:",inline"`
 	// Standard list metadata.
 	// +optional
 	metav1.ListMeta `json:"metadata,omitempty"`
-	// List of endpoint slices
+	// List of service imports
 	// +listType=set
 	Items []ServiceImport `json:"items"`
 }


### PR DESCRIPTION
This repository has no PR template, so this is a plain description.

`ServiceImportList` and `ServiceExportList`, in both `v1alpha1` and `v1beta1`, had doc comments saying they represent "a list of endpoint slices" (both the type doc comment and the `Items` field comment), clearly copy-pasted from an `EndpointSliceList` type and never corrected. Fixed to say "a list of service imports" / "a list of service exports" as appropriate.

Doc-comment-only change. Ran `make manifests` and `make generate`; neither produced any further diff, since these list-wrapper types' doc comments don't flow into the generated CRD schema (only the individual `ServiceImport`/`ServiceExport` resource types do). `go build ./...` and `go vet ./...` both pass.
