### PR TITLE
Fix CONTRIBUTING.md pointing at sig-service-catalog

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -22,5 +22,5 @@ If your repo has certain guidelines for contribution, put them here ahead of the
 
 ## Contact Information
 
-- [Slack](https://kubernetes.slack.com/messages/sig-service-catalog)
-- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-service-catalog)
+- [Slack](https://kubernetes.slack.com/messages/sig-multicluster)
+- [Mailing List](https://groups.google.com/forum/#!forum/kubernetes-sig-multicluster)


### PR DESCRIPTION
This repository has no PR template, so this is a plain description.

`CONTRIBUTING.md`'s Slack and mailing list links pointed at `sig-service-catalog`, leftover boilerplate from the shared Kubernetes-sigs repo template that was never updated for this repo. This repo's own `README.md` already correctly links to `sig-multicluster`, and the sibling repo `work-api`'s `CONTRIBUTING.md` (same template) has the correct links too. Fixed both links to match.

Doc-only change.
