### PR TITLE
Stop shadowing the package level cfg in BeforeSuite

### DIFF
--- a/controllers/controllers_suite_test.go
+++ b/controllers/controllers_suite_test.go
@@ -62,7 +62,7 @@ var _ = BeforeSuite(func(ctx context.Context) {
 	kubeconfig, err := clusterProvider.KubeConfig(clusterName, false)
 	Expect(err).ToNot(HaveOccurred())
 
-	cfg, err := clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
+	cfg, err = clientcmd.RESTConfigFromKubeConfig([]byte(kubeconfig))
 	Expect(err).ToNot(HaveOccurred())
 	scheme := runtime.NewScheme()
 	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())


### PR DESCRIPTION
This repository has no PR template, so this is a plain description.

`controllers/controllers_suite_test.go`'s `BeforeSuite` had `cfg, err := clientcmd.RESTConfigFromKubeConfig(...)`, which declares a new local `cfg` (since `err` was already in scope from the line above, `:=` only needs one new variable, and `cfg` isn't declared in this function's local scope). That shadows the package-level `var cfg *rest.Config`, so the package var stays nil forever and every subsequent use in the function reads the local shadow instead. Changed `:=` to `=` so it assigns to the package-level var, matching the later `cfg, err = env.Start()` line, which already does this correctly. `golangci-lint`'s `unused` check flagged the package-level `cfg` as dead; this fixes that.

Functionally harmless today since nothing outside this function reads the package-level `cfg`, but it's a real bug the linter caught and a one-character fix.

Note: this same file is also touched by open PR #167 (adds `RunSpecs(...)` at the very end), in a different part of the file, so should apply/rebase cleanly.

Tested: `go build ./...` and `go vet ./...` pass in the `controllers` module. `golangci-lint run ./...` no longer flags `cfg` as unused.
