### PR TITLE
Return manager creation error instead of exiting process

### DIFF
--- a/controllers/common.go
+++ b/controllers/common.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
+	"fmt"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -45,8 +46,7 @@ func derivedName(name types.NamespacedName) string {
 func Start(ctx context.Context, cfg *rest.Config, setupLog logr.Logger, opts ctrl.Options) error {
 	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {
-		setupLog.Error(err, "unable to start manager")
-		return err
+		return fmt.Errorf("unable to start manager: %w", err)
 	}
 
 	if err = (&ServiceImportReconciler{

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -20,7 +20,6 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/base32"
-	"os"
 	"strings"
 
 	"github.com/go-logr/logr"
@@ -47,7 +46,7 @@ func Start(ctx context.Context, cfg *rest.Config, setupLog logr.Logger, opts ctr
 	mgr, err := ctrl.NewManager(cfg, opts)
 	if err != nil {
 		setupLog.Error(err, "unable to start manager")
-		os.Exit(1)
+		return err
 	}
 
 	if err = (&ServiceImportReconciler{

--- a/controllers/common.go
+++ b/controllers/common.go
@@ -53,28 +53,24 @@ func Start(ctx context.Context, cfg *rest.Config, setupLog logr.Logger, opts ctr
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("ServiceImport"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "ServiceImport")
-		return err
+		return fmt.Errorf("unable to create controller %q: %w", "ServiceImport", err)
 	}
 	if err = (&ServiceReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("Service"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "Service")
-		return err
+		return fmt.Errorf("unable to create controller %q: %w", "Service", err)
 	}
 	if err = (&EndpointSliceReconciler{
 		Client: mgr.GetClient(),
 		Log:    ctrl.Log.WithName("controllers").WithName("EndpointSlice"),
 	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "EndpointSlice")
-		return err
+		return fmt.Errorf("unable to create controller %q: %w", "EndpointSlice", err)
 	}
 
 	setupLog.Info("starting manager")
 	if err := mgr.Start(ctx); err != nil {
-		setupLog.Error(err, "problem running manager")
-		return err
+		return fmt.Errorf("problem running manager: %w", err)
 	}
 	return nil
 }


### PR DESCRIPTION
This repository has no PR template, so this is a plain description.

Start calls os.Exit(1) directly when ctrl.NewManager fails, even though every other error path in the same function returns the error to the caller. This makes the failure untestable and kills the whole process abruptly, which is especially disruptive for callers like the envtest suite that invoke Start in a goroutine.

Checked the production caller (controllers/cmd/servicecontroller/servicecontroller.go): it already checks the error returned by controllers.Start and calls os.Exit(1) itself, so production behavior is unchanged. This only fixes the internal inconsistency inside Start.

Tested: go build ./... and go vet ./... pass in both the root module and the controllers module.